### PR TITLE
Skills small changes

### DIFF
--- a/mmf_sa/models/abstract_model.py
+++ b/mmf_sa/models/abstract_model.py
@@ -29,7 +29,7 @@ MODEL_PIP_REQUIREMENTS = {
         MMF_PACKAGE,
     ],
     "timesfm": [
-        "timesfm[torch] @ git+https://github.com/google-research/timesfm.git@2dcc66fbfe2155adba1af66aa4d564a0ee52f61e",
+        "timesfm[torch,xreg] @ git+https://github.com/google-research/timesfm.git@2dcc66fbfe2155adba1af66aa4d564a0ee52f61e",
         MMF_PACKAGE,
     ],
     "moirai": [

--- a/skills/README.md
+++ b/skills/README.md
@@ -20,7 +20,7 @@ The Many-Model Forecasting skill teaches AI assistants how to:
 - **Prepare and clean** time series data with automated imputation and anomaly capping
 - **Profile and classify** series by forecastability using statistical properties (ADF, STL, spectral entropy, SNR)
 - **Handle non-forecastable series** — the user chooses to keep them, apply a simple fallback (Naive, Seasonal Naive, Mean, Zero), or run a separate pipeline with dedicated models
-- **Provision** the right Databricks clusters (CPU or GPU) based on model requirements and dataset size
+- **Provision** the right Databricks clusters (CPU with 16 or 32 vCPU options, or GPU) based on model requirements and dataset size
 - **Execute** forecasting pipelines using **StatsForecast**, **SKTime**, **NeuralForecast**, **Chronos**, and **TimesFM** models
 - **Evaluate** results with multi-metric analysis, best-model selection per series, and business-ready summaries with `forecast_source` tracking
 
@@ -56,7 +56,7 @@ All generated assets are prefixed with a user-provided **use case name** (e.g., 
 | ----- | ---------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | 1     | `/prep-and-clean-data`             | Discover tables, map columns, ask user about imputation and anomaly handling                           |
 | 2     | `/profile-and-classify-series`     | **(Optional)** Compute statistical properties, classify forecastability, recommend models, ask user how to handle non-forecastable series (serverless) |
-| 3     | `/provision-forecasting-resources` | Ask user which models and clusters, configure CPU/GPU; size separate NF cluster if needed              |
+| 3     | `/provision-forecasting-resources` | Ask user which models and clusters, configure CPU (16 vCPU default, 32 vCPU option) / GPU; size separate NF cluster if needed |
 | 4     | `/execute-mmf-forecast`            | Generate orchestrator + run notebooks, create one job per model class (+ NF jobs), run in parallel     |
 | 5     | `/post-process-and-evaluate`       | Best-model selection, WAPE/sMAPE metrics, merge NF results, evaluation summary with `forecast_source`  |
 
@@ -116,7 +116,9 @@ your-project/
     ├── mmf_local_notebook_template.ipynb
     ├── mmf_gpu_run_notebook_template.ipynb
     ├── mmf_gpu_orchestrator_notebook_template.ipynb
-    └── mmf_profiling_notebook_template.ipynb
+    ├── mmf_profiling_notebook_template.ipynb
+    ├── mmf_prep_notebook_template.ipynb
+    └── mmf_post_process_notebook_template.ipynb
 ```
 
 Re-running the installer is safe — it updates existing configurations without duplication.

--- a/skills/databricks-skills/many-model-forecasting/1-prep-and-clean-data.md
+++ b/skills/databricks-skills/many-model-forecasting/1-prep-and-clean-data.md
@@ -182,9 +182,95 @@ AskUserQuestion:
 
 If the user selects (b), (c), or (d), update the mapping accordingly and re-present this confirmation prompt before proceeding.
 
-Also ask at this step:
+### ⛔ STOP GATE — Step 5a: Ask about exogenous regressors
 
-- Any optional exogenous regressors to include (columns to carry through alongside `y`)
+**Only ask this after the user has confirmed the column mapping above. Ask one question at a time.**
+
+```
+AskUserQuestion:
+  "Does your source table have any exogenous regressor columns you want to
+   include alongside the target variable (y)?
+
+   (1) Yes — I have additional columns to include
+   (2) No — run in univariate mode (no exogenous regressors)"
+```
+
+**WAIT for the user to respond.**
+
+If the user selects (2), set all regressor lists to `[]` and skip to Step 6.
+
+If the user selects (1), ask which types they have:
+
+```
+AskUserQuestion:
+  "Which types of regressors do you have? Select all that apply:
+
+   (a) Static features — constant per series / group
+       (e.g., store_state, dept_id, product_category)
+   (b) Dynamic historical — past-only values, NOT needed at forecast time
+       (e.g., lagged sales, rolling averages, past event flags)
+   (c) Dynamic future — values known for BOTH past AND future dates
+       (e.g., planned price, temperature forecast, promo flag, holiday indicator)
+
+   Which types? (e.g., 'a and c', or just 'c')"
+```
+
+**WAIT for the user to respond.**
+
+For each type the user selected, ask a separate follow-up question to collect the column names:
+
+**If static features selected:**
+```
+AskUserQuestion:
+  "List the static feature column names (constant per series):
+   e.g., store_state, dept_id"
+```
+
+**WAIT for the user to respond.** Store as `{static_features}`.
+
+**If dynamic historical selected:**
+```
+AskUserQuestion:
+  "List the dynamic historical column names (past-only, not needed at forecast time).
+   Separate numerical and categorical:
+   • Numerical (e.g., lagged_sales, rolling_avg):
+   • Categorical (e.g., past_event_type):"
+```
+
+**WAIT for the user to respond.** Store as `{dynamic_historical_numerical}` and `{dynamic_historical_categorical}`.
+
+**If dynamic future selected:**
+```
+AskUserQuestion:
+  "List the dynamic future column names (known for both past AND future dates).
+   Separate numerical and categorical:
+   • Numerical (e.g., planned_price, temperature_forecast):
+   • Categorical (e.g., promo, day_of_week, holiday, open_closed):
+
+   ⚠️  You MUST have known future values for every series × every future date
+   in the forecast horizon. I will create a scoring table from this data."
+```
+
+**WAIT for the user to respond.** Store as `{dynamic_future_numerical}` and `{dynamic_future_categorical}`.
+
+### ⛔ STOP GATE — Step 5b: Ask where future regressor values come from
+
+**Only ask this if the user selected dynamic future regressors above.**
+
+```
+AskUserQuestion:
+  "Where do the future values for {dynamic_future_columns} come from?
+
+   (a) Same source table — rows beyond the last training date already contain
+       the future regressor values (e.g., a calendar or schedule table that
+       extends into the future)
+   (b) Separate table — provide the table name containing future-dated rows
+       with the regressor columns"
+```
+
+**WAIT for the user to respond.**
+
+Store the answer as `{future_regressor_source}` (`same_table` or the name of the separate table). If the user selects (b), ask for the table name in a follow-up question before proceeding.
 
 ### Step 6: Create {use_case}_train_data
 
@@ -240,13 +326,188 @@ WHERE {y_col} IS NOT NULL
 GROUP BY {unique_id_col}, LAST_DAY({ds_col})
 ```
 
-If exogenous regressors were selected, include them as additional columns (use `SUM` for numeric regressors when aggregating).
+If exogenous regressors were selected, include them as additional columns (use `SUM` for numeric regressors when aggregating, and `FIRST` or `MAX` for categorical regressors when aggregating).
 
 Verify creation:
 
 ```sql
 SELECT COUNT(*) AS count FROM {catalog}.{schema}.{use_case}_train_data
 ```
+
+### Step 6a: Create {use_case}_scoring_data (if dynamic future regressors)
+
+**Only run this step if the user selected dynamic future regressors (`dynamic_future_numerical` or `dynamic_future_categorical`) in Step 5.**
+
+The scoring table must contain one row per `unique_id` × future `ds` for each date in the forecast horizon, with all dynamic future regressor columns populated. During scoring, `run_forecast` unions this table with `train_data` via `unionByName(score_df, allowMissingColumns=True)` — columns present in `train_data` but absent from the scoring table (such as `y`) are automatically filled with NULL.
+
+**Required schema — must match the Rossmann example pattern** (see [local_univariate_external_regressors_daily.ipynb](https://github.com/databricks-industry-solutions/many-model-forecasting/blob/main/examples/external_regressors/local_univariate_external_regressors_daily.ipynb)):
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `unique_id` | STRING | Series identifier (same column as in `train_data`) |
+| `ds` | DATE or TIMESTAMP | Future dates only — dates beyond the last training date |
+| Each `dynamic_future_numerical` column | DOUBLE / FLOAT / INT | Known future numerical regressor values |
+| Each `dynamic_future_categorical` column | STRING / INT | Known future categorical regressor values |
+
+**Do NOT include the target column (`y`).** The `allowMissingColumns=True` union fills it as NULL automatically. This matches the Rossmann example where `rossmann_daily_test` has `Store`, `Date`, and the regressor columns but no `Sales`.
+
+**Do NOT include `static_features` or `dynamic_historical_*` columns.** These are either constant per series (extracted from training data by the model) or past-only (not relevant for future dates). The `allowMissingColumns=True` union handles them.
+
+#### Source: same table (option a)
+
+If the future regressor values come from the **same source table** (rows beyond the training period's end date):
+
+```sql
+CREATE OR REPLACE TABLE {catalog}.{schema}.{use_case}_scoring_data AS
+SELECT
+    CAST({unique_id_col} AS STRING) AS unique_id,
+    CAST({ds_col} AS DATE) AS ds,
+    {dynamic_future_columns}
+FROM {catalog}.{schema}.{table_name}
+WHERE {ds_col} > (SELECT MAX(ds) FROM {catalog}.{schema}.{use_case}_train_data)
+```
+
+Adjust the `CAST({ds_col} ...)` and date filtering to match the detected frequency (TIMESTAMP for hourly, DATE for daily/weekly/monthly). For weekly/monthly frequencies, apply the same alignment logic as Step 6 (e.g., `DATE_TRUNC('week', ...) + INTERVAL 6 DAY` for weekly, `LAST_DAY(...)` for monthly) and aggregate regressors accordingly.
+
+#### Source: separate table (option b)
+
+If the future regressor values come from a **separate table**:
+
+```sql
+CREATE OR REPLACE TABLE {catalog}.{schema}.{use_case}_scoring_data AS
+SELECT
+    CAST({future_unique_id_col} AS STRING) AS unique_id,
+    CAST({future_ds_col} AS DATE) AS ds,
+    {dynamic_future_columns}
+FROM {catalog}.{schema}.{future_regressor_table}
+WHERE {future_ds_col} > (SELECT MAX(ds) FROM {catalog}.{schema}.{use_case}_train_data)
+```
+
+Ask the user to confirm the column mapping for `unique_id` and `ds` in the separate table if the column names differ from the source training table.
+
+#### Validation
+
+After creating the scoring table, verify coverage:
+
+```sql
+-- Check row count and date range
+SELECT
+    COUNT(*) AS scoring_rows,
+    COUNT(DISTINCT unique_id) AS n_series,
+    MIN(ds) AS min_future_ds,
+    MAX(ds) AS max_future_ds
+FROM {catalog}.{schema}.{use_case}_scoring_data
+```
+
+```sql
+-- Check that every training series has scoring rows
+SELECT COUNT(*) AS series_missing_scoring
+FROM (
+    SELECT DISTINCT unique_id FROM {catalog}.{schema}.{use_case}_train_data
+    EXCEPT
+    SELECT DISTINCT unique_id FROM {catalog}.{schema}.{use_case}_scoring_data
+)
+```
+
+```sql
+-- Check for NULL values in dynamic future regressor columns
+SELECT
+    {for each col in dynamic_future_columns:
+    SUM(CASE WHEN {col} IS NULL THEN 1 ELSE 0 END) AS {col}_nulls,}
+    COUNT(*) AS total_rows
+FROM {catalog}.{schema}.{use_case}_scoring_data
+```
+
+**If `series_missing_scoring > 0`**, warn the user:
+> "⚠️ {series_missing_scoring} series in training data have no future regressor values in the scoring table. These series will be dropped from scoring. Would you like to (a) proceed anyway, (b) exclude those series from training too, or (c) provide a corrected scoring source?"
+
+#### ⛔ STOP GATE — Scoring data NULL handling
+
+**If any dynamic future columns have NULLs, always ask the user how to handle them. Do NOT proceed until the user confirms.**
+
+Present the NULL summary and ask for a strategy:
+
+```
+AskUserQuestion:
+  "The scoring table has NULL values in some dynamic future regressor columns:
+
+   {for each column with nulls:
+   • {col}: {n_nulls} NULLs out of {total_rows} rows ({null_pct}%)}
+
+   NULL regressor values will cause errors or silently drop affected series
+   during forecasting. How would you like to fill them?
+
+   (a) Forward fill — carry the last known value from training data forward
+       (good for slowly changing features like price or staffing level)
+   (b) Fill with a specific value — enter a default per column
+       (good for binary flags like promo=0, open=1)
+   (c) Fill with the column's mode (most frequent value)
+       (good for categorical columns like day_of_week or holiday)
+   (d) Fill with the column's mean (numerical columns only)
+       (good for continuous regressors like temperature)
+   (e) Drop rows with NULLs — remove incomplete future dates
+   (f) Proceed as-is — keep NULLs (⚠️ may cause pipeline errors)"
+```
+
+**WAIT for the user to respond. Do NOT apply any fill strategy until the user confirms.**
+
+Apply the chosen strategy:
+
+- **(a) Forward fill**: For each series, carry the last known value from the training table into the scoring rows:
+  ```sql
+  -- For each column with NULLs, get the last known value per series from train_data
+  UPDATE {catalog}.{schema}.{use_case}_scoring_data s
+  SET {col} = (
+      SELECT {col}
+      FROM {catalog}.{schema}.{use_case}_train_data t
+      WHERE t.unique_id = s.unique_id
+        AND t.{col} IS NOT NULL
+      ORDER BY t.ds DESC
+      LIMIT 1
+  )
+  WHERE s.{col} IS NULL
+  ```
+- **(b) Fill with specific value**: Ask the user for a default value per column, then:
+  ```sql
+  UPDATE {catalog}.{schema}.{use_case}_scoring_data
+  SET {col} = {user_specified_default}
+  WHERE {col} IS NULL
+  ```
+- **(c) Fill with mode**:
+  ```sql
+  UPDATE {catalog}.{schema}.{use_case}_scoring_data
+  SET {col} = (
+      SELECT {col} FROM {catalog}.{schema}.{use_case}_train_data
+      GROUP BY {col} ORDER BY COUNT(*) DESC LIMIT 1
+  )
+  WHERE {col} IS NULL
+  ```
+- **(d) Fill with mean** (numerical columns only):
+  ```sql
+  UPDATE {catalog}.{schema}.{use_case}_scoring_data
+  SET {col} = (SELECT AVG({col}) FROM {catalog}.{schema}.{use_case}_train_data)
+  WHERE {col} IS NULL
+  ```
+- **(e) Drop rows**: Remove incomplete rows from the scoring table:
+  ```sql
+  DELETE FROM {catalog}.{schema}.{use_case}_scoring_data
+  WHERE {col_1} IS NULL OR {col_2} IS NULL OR ...
+  ```
+- **(f) Proceed as-is**: Skip — warn the user again that this may cause pipeline errors.
+
+After applying the chosen strategy (unless option f), verify no NULLs remain:
+
+```sql
+SELECT
+    {for each col in dynamic_future_columns:
+    SUM(CASE WHEN {col} IS NULL THEN 1 ELSE 0 END) AS {col}_nulls,}
+    COUNT(*) AS total_rows
+FROM {catalog}.{schema}.{use_case}_scoring_data
+```
+
+If NULLs still remain (e.g., forward fill had no non-NULL training value), warn the user and suggest a fallback strategy.
+
+Present the final scoring table summary to the user before continuing.
 
 ### Step 7: Missing Data Assessment & Imputation
 
@@ -597,6 +858,13 @@ AskUserQuestion:
    • Imputation: {imputation_summary}
    • Anomalies: {anomaly_summary}
    • Cleaning report: {catalog}.{schema}.{use_case}_cleaning_report
+   {if dynamic_future_regressors:
+   • Scoring table: {catalog}.{schema}.{use_case}_scoring_data
+     — {scoring_n_series} series × {scoring_date_range} future dates
+     — Dynamic future columns: {dynamic_future_columns}
+   }
+   {if static_features: '• Static features: {static_features}'}
+   {if dynamic_historical: '• Dynamic historical features: {dynamic_historical_columns}'}
    • Reproducibility notebook: notebooks/{use_case}/prep_data
 
    Would you like to proceed to the next step?
@@ -609,9 +877,11 @@ AskUserQuestion:
 
 ## Outputs
 
-- A conversation-carried `**{forecast_problem_brief}`** (3–6 lines) for downstream skills and optional research scoping
-- A Delta table `<catalog>.<schema>.{use_case}_train_data` with columns `unique_id` (STRING), `ds` (DATE for D/W/M, TIMESTAMP for H), `y` (DOUBLE)
+- A conversation-carried **`{forecast_problem_brief}`** (3–6 lines) for downstream skills and optional research scoping
+- A Delta table `<catalog>.<schema>.{use_case}_train_data` with columns `unique_id` (STRING), `ds` (DATE for D/W/M, TIMESTAMP for H), `y` (DOUBLE), plus any exogenous regressor columns
 - A Delta table `<catalog>.<schema>.{use_case}_cleaning_report` with columns: `unique_id`, `original_count`, `final_count`, `missing_filled`, `imputation_method`, `anomalies_capped`, `iqr_multiplier`, `excluded`, `exclusion_reason`
+- **(If dynamic future regressors)** A Delta table `<catalog>.<schema>.{use_case}_scoring_data` with columns `unique_id` (STRING), `ds` (DATE/TIMESTAMP — future dates only), plus all dynamic future regressor columns. Does NOT include `y`, `static_features`, or `dynamic_historical_*` columns — `run_forecast` unions this with `train_data` via `allowMissingColumns=True`. This table is passed as `scoring_data` to `run_forecast` in Skill 4.
+- Exogenous regressor column lists carried forward: `{static_features}`, `{dynamic_future_numerical}`, `{dynamic_future_categorical}`, `{dynamic_historical_numerical}`, `{dynamic_historical_categorical}`
 - A reproducibility notebook uploaded to `notebooks/{use_case}/prep_data` that can re-create the training table with the same parameters
 - A summary: number of series, date range, detected frequency, cleaning actions taken
 

--- a/skills/databricks-skills/many-model-forecasting/1-prep-and-clean-data.md
+++ b/skills/databricks-skills/many-model-forecasting/1-prep-and-clean-data.md
@@ -22,6 +22,7 @@ AskUserQuestion:
 ```
 
 Validation rules:
+
 - Lowercase alphanumeric + underscores only (must be valid as a Delta table name component)
 - 1-30 characters
 - Cannot start with a number
@@ -67,7 +68,7 @@ AskUserQuestion:
    • How the forecast will be used (operations, finance, capacity, etc.)
    • Rough horizon you care about
    • Whether your series are smooth, seasonal, intermittent/sparse, or unknown
-   • Mostly many univariate series (standard MMF) vs. heavy exogenous / multivariate
+   • Univariate series vs. exogenous / covariate
 
    Reply in free text; I'll condense to a short brief for downstream steps."
   Options: [free text]
@@ -102,6 +103,7 @@ DESCRIBE TABLE {catalog}.{schema}.{table_name}
 ```
 
 Identify time series candidates by checking column types:
+
 - **Timestamp/date column (`ds`)**: columns with type `TIMESTAMP`, `DATE`, or `STRING` with date-like names (`ds`, `date`, `timestamp`, `time`, `datetime`)
 - **Target numeric column (`y`)**: columns with type `DOUBLE`, `FLOAT`, `INT`, `BIGINT`, `DECIMAL` with names suggesting a metric (`y`, `value`, `target`, `amount`, `quantity`, `sales`, `count`)
 - **Group identifier (`unique_id`)**: columns with type `STRING`, `INT`, or `BIGINT` that appear to be categorical identifiers (`unique_id`, `id`, `store_id`, `product_id`, `sku`, `series_id`)
@@ -113,16 +115,19 @@ A valid time series table MUST have all three: a date column, a numeric column, 
 For each candidate table, run these queries:
 
 **Row count:**
+
 ```sql
 SELECT COUNT(*) AS count FROM {catalog}.{schema}.{table_name}
 ```
 
 **Date range:**
+
 ```sql
 SELECT MIN({ds_col}) AS min_ds, MAX({ds_col}) AS max_ds FROM {catalog}.{schema}.{table_name}
 ```
 
 **Number of distinct groups:**
+
 ```sql
 SELECT COUNT(DISTINCT {unique_id_col}) AS unique_count FROM {catalog}.{schema}.{table_name}
 ```
@@ -142,6 +147,7 @@ FROM (
 ```
 
 **Interpretation:**
+
 - `avg_gap` < 0.1 = **Hourly** (`freq=H`)
 - `avg_gap` ~1 = **Daily** (`freq=D`)
 - `avg_gap` ~7 = **Weekly** (`freq=W`)
@@ -177,6 +183,7 @@ AskUserQuestion:
 If the user selects (b), (c), or (d), update the mapping accordingly and re-present this confirmation prompt before proceeding.
 
 Also ask at this step:
+
 - Any optional exogenous regressors to include (columns to carry through alongside `y`)
 
 ### Step 6: Create {use_case}_train_data
@@ -184,6 +191,7 @@ Also ask at this step:
 Create the training table with the MMF-required schema. The SQL depends on the detected (or user-specified) frequency to ensure dates are properly aligned:
 
 **Hourly (`freq=H`) — no date transformation needed:**
+
 ```sql
 CREATE OR REPLACE TABLE {catalog}.{schema}.{use_case}_train_data AS
 SELECT
@@ -195,6 +203,7 @@ WHERE {y_col} IS NOT NULL
 ```
 
 **Daily (`freq=D`) — no date transformation needed:**
+
 ```sql
 CREATE OR REPLACE TABLE {catalog}.{schema}.{use_case}_train_data AS
 SELECT
@@ -206,6 +215,7 @@ WHERE {y_col} IS NOT NULL
 ```
 
 **Weekly (`freq=W`) — align dates to Sunday (end of ISO week) and aggregate:**
+
 ```sql
 CREATE OR REPLACE TABLE {catalog}.{schema}.{use_case}_train_data AS
 SELECT
@@ -218,6 +228,7 @@ GROUP BY {unique_id_col}, DATE_TRUNC('week', {ds_col}) + INTERVAL 6 DAY
 ```
 
 **Monthly (`freq=M`) — align dates to month-end and aggregate:**
+
 ```sql
 CREATE OR REPLACE TABLE {catalog}.{schema}.{use_case}_train_data AS
 SELECT
@@ -232,6 +243,7 @@ GROUP BY {unique_id_col}, LAST_DAY({ds_col})
 If exogenous regressors were selected, include them as additional columns (use `SUM` for numeric regressors when aggregating).
 
 Verify creation:
+
 ```sql
 SELECT COUNT(*) AS count FROM {catalog}.{schema}.{use_case}_train_data
 ```
@@ -239,6 +251,7 @@ SELECT COUNT(*) AS count FROM {catalog}.{schema}.{use_case}_train_data
 ### Step 7: Missing Data Assessment & Imputation
 
 Missing data in time series comes in three forms, all of which must be detected:
+
 - **Explicit NULLs**: Rows exist but `y` is NULL.
 - **Interior gaps**: Entire rows are absent between the first and last timestamp of a series.
 - **Trailing gaps**: A series ends before the global max date. For example, if most series run through Dec 2024 but three end at Nov 2024, those three have a one-month trailing gap. This is critical to detect because MMF expects all series to share the same end date.
@@ -283,6 +296,7 @@ ORDER BY missing_pct DESC
 ```
 
 The `SEQUENCE` interval changes by frequency:
+
 - Hourly (`freq=H`): `INTERVAL 1 HOUR`
 - Daily (`freq=D`): `INTERVAL 1 DAY`
 - Weekly (`freq=W`): `INTERVAL 7 DAY`
@@ -368,6 +382,33 @@ Then apply the chosen imputation on the now-explicit NULLs:
 - **Forward fill**: `LAST_VALUE(y IGNORE NULLS) OVER (PARTITION BY unique_id ORDER BY ds)`
 - **Fill with 0**: `COALESCE(y, 0)` — appropriate for count/demand data where absence means zero activity
 - **Exclusion**: Remove series exceeding the threshold from `{use_case}_train_data`
+
+> **Trailing-gap fallback (required after interpolation).** Linear interpolation needs a future neighbor via `LEAD(y IGNORE NULLS)`. For trailing gaps — rows beyond a series' last observed value — there is no future data point, so `LEAD` returns NULL and interpolation leaves those rows unfilled. After applying interpolation, always run a forward-fill pass on any remaining NULLs:
+>
+> ```sql
+> UPDATE {catalog}.{schema}.{use_case}_train_data t
+> SET y = (
+>   SELECT LAST_VALUE(t2.y IGNORE NULLS) OVER (
+>     PARTITION BY t2.unique_id ORDER BY t2.ds
+>     ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+>   )
+>   FROM {catalog}.{schema}.{use_case}_train_data t2
+>   WHERE t2.unique_id = t.unique_id AND t2.ds = t.ds
+> )
+> WHERE t.y IS NULL
+> ```
+>
+> This only affects trailing positions where interpolation could not reach. Forward-fill and fill-with-0 strategies do not need this extra step.
+
+After imputation, verify no NULLs remain:
+
+```sql
+SELECT COUNT(*) AS remaining_nulls
+FROM {catalog}.{schema}.{use_case}_train_data
+WHERE y IS NULL
+```
+
+If `remaining_nulls > 0`, warn the user and suggest excluding those series or switching to forward-fill.
 
 Log the count of imputed values per series and excluded series for the cleaning report.
 
@@ -516,6 +557,7 @@ After all interactive decisions have been made, generate a self-contained notebo
 **CRITICAL: Copy the template VERBATIM from `mmf_prep_notebook_template.ipynb`, only replacing the `{placeholder}` tokens with actual values. Do NOT add, remove, or modify any other code.**
 
 Replace these placeholders:
+
 - `{catalog}` → user's catalog
 - `{schema}` → user's schema
 - `{use_case}` → use case name
@@ -529,11 +571,13 @@ Replace these placeholders:
 - `{iqr_multiplier}` → IQR multiplier as float (e.g., `1.5`; `0` = skip capping)
 
 Save the generated notebook to the **local project directory** at:
+
 - `notebooks/{use_case}/prep_data.ipynb`
 
 Then upload it to the Databricks workspace at `notebooks/{use_case}/prep_data`.
 
 Use the template from:
+
 - [mmf_prep_notebook_template.ipynb](mmf_prep_notebook_template.ipynb)
 
 ### ⛔ STOP GATE — Step 11: Confirm before proceeding to next skill
@@ -565,8 +609,9 @@ AskUserQuestion:
 
 ## Outputs
 
-- A conversation-carried **`{forecast_problem_brief}`** (3–6 lines) for downstream skills and optional research scoping
+- A conversation-carried `**{forecast_problem_brief}`** (3–6 lines) for downstream skills and optional research scoping
 - A Delta table `<catalog>.<schema>.{use_case}_train_data` with columns `unique_id` (STRING), `ds` (DATE for D/W/M, TIMESTAMP for H), `y` (DOUBLE)
 - A Delta table `<catalog>.<schema>.{use_case}_cleaning_report` with columns: `unique_id`, `original_count`, `final_count`, `missing_filled`, `imputation_method`, `anomalies_capped`, `iqr_multiplier`, `excluded`, `exclusion_reason`
 - A reproducibility notebook uploaded to `notebooks/{use_case}/prep_data` that can re-create the training table with the same parameters
 - A summary: number of series, date range, detected frequency, cleaning actions taken
+

--- a/skills/databricks-skills/many-model-forecasting/3-provision-forecasting-resources.md
+++ b/skills/databricks-skills/many-model-forecasting/3-provision-forecasting-resources.md
@@ -280,91 +280,115 @@ Only created when `non_forecastable_strategy == 'separate_job'` and the non-fore
 
 **Always present the cluster configuration and ask the user to confirm. Do NOT proceed until the user approves.**
 
-Present the computed configuration and let the user customize:
+Ask about each cluster one at a time. Only ask about cluster types the user's selected models require.
+
+#### Step 6a: CPU cluster configuration (if local models selected)
 
 ```
 AskUserQuestion:
-  "Here is the proposed cluster configuration for your selected models:
-
-   ── CPU CLUSTERS (local models) ──
-
-   {if local models selected:
-   Main CPU Cluster ({use_case}_cpu_cluster):
+  "CPU Cluster ({use_case}_cpu_cluster) — for local models:
      • Runtime: 17.3.x-cpu-ml-scala2.13
-     • Node type: (select one)
 
-     AWS:
-     (a) i3.4xlarge   — 16 vCPUs, 122 GB  (recommended)
-     (b) i3.8xlarge   — 32 vCPUs, 244 GB  (high-parallelism or wide features)
+   Which instance type?
 
-     Azure:
-     (a) Standard_DS5_v2    — 16 vCPUs, 56 GB  (recommended)
-     (b) Standard_D32ds_v5  — 32 vCPUs, 128 GB (high-parallelism or wide features)
+   {cloud-specific options for the user's provider only:}
 
-     GCP:
-     (a) n1-standard-16 — 16 vCPUs, 60 GB  (recommended)
-     (b) n1-standard-32 — 32 vCPUs, 120 GB (high-parallelism or wide features)
+   AWS:
+   (a) i3.4xlarge   — 16 vCPUs, 122 GB  (recommended)
+   (b) i3.8xlarge   — 32 vCPUs, 244 GB  (high-parallelism or wide features)
 
-     • Forecastable series: {n_series}
-     • Recommended workers: {recommended_workers} (see sizing guide)
-     ❓ How many workers do you want for the CPU cluster?
+   Azure:
+   (a) Standard_DS5_v2    — 16 vCPUs, 56 GB  (recommended)
+   (b) Standard_D32ds_v5  — 32 vCPUs, 128 GB (high-parallelism or wide features)
 
-     {if non_forecastable_strategy == 'separate_job' and nf_local_models:
-     NF CPU Cluster ({use_case}_nf_cpu_cluster):
-       • Same node type as main CPU cluster
-       • Non-forecastable series: {n_nf_series}
-       • Recommended workers: {nf_recommended_workers} (see sizing guide)
-       ❓ How many workers do you want for the NF CPU cluster?
-     }
-   }
-
-   ── GPU CLUSTERS (global & foundation models) — SINGLE NODE ──
-
-   {if global or foundation models selected:
-   Main GPU Cluster ({use_case}_gpu_cluster):
-     • Runtime: 18.0.x-gpu-ml-scala2.13
-     • Node type: (select one)
-
-     AWS:
-     (a) g5.xlarge    — 1× A10G GPU, 24 GB  (small foundation models)
-     (b) g5.2xlarge   — 1× A10G GPU, 24 GB, more CPU/RAM
-     (c) g5.12xlarge  — 4× A10G GPUs, 96 GB  (recommended for global + foundation)
-     (d) g5.48xlarge  — 8× A10G GPUs, 192 GB (large-scale training)
-
-     Azure:
-     (a) Standard_NC4as_T4_v3    — 1× T4 GPU, 16 GB
-     (b) Standard_NC8as_T4_v3    — 1× T4 GPU, 16 GB, more CPU/RAM
-     (c) Standard_NV36ads_A10_v5 — 1× A10 GPU, 24 GB  (recommended)
-     (d) Standard_NV72ads_A10_v5 — 2× A10 GPUs, 48 GB (global + foundation)
-     (e) Standard_NC24ads_A100_v4 — 1× A100 GPU, 80 GB (large models)
-
-     GCP:
-     (a) g2-standard-4   — 1× L4 GPU, 24 GB
-     (b) g2-standard-8   — 1× L4 GPU, 24 GB, more CPU/RAM
-     (c) g2-standard-48  — 4× L4 GPUs, 96 GB  (recommended)
-     (d) a2-highgpu-1g   — 1× A100 GPU, 40 GB (large models)
-
-     {if non_forecastable_strategy == 'separate_job' and nf_gpu_models:
-     NF GPU Cluster ({use_case}_nf_gpu_cluster):
-       • Same config as main GPU cluster — smaller instance usually sufficient
-       • Node type: (select from options above)
-     }
-   }
-
-   {if non_forecastable_strategy == 'separate_job':
-   Non-forecastable models: {non_forecastable_models}
-   }
-
-   Would you like to:
-   (1) Accept the proposed configuration
-   (2) Change the CPU instance type or worker count
-   (3) Select a different GPU instance type
-   (4) Change both CPU and GPU configuration
-   {if non_forecastable_strategy == 'separate_job':
-   (5) Change non-forecastable cluster configuration}"
+   GCP:
+   (a) n1-standard-16 — 16 vCPUs, 60 GB  (recommended)
+   (b) n1-standard-32 — 32 vCPUs, 120 GB (high-parallelism or wide features)"
 ```
 
-**WAIT for the user to respond. Do NOT create any clusters until the user confirms.**
+**WAIT for the user to respond.**
+
+Then ask about worker count separately:
+
+```
+AskUserQuestion:
+  "How many workers for the CPU cluster?
+
+   • Forecastable series: {n_series}
+   • Recommended workers: {recommended_workers}
+
+   Sizing guide:
+     < 100 series → 0 (single-node)
+     100–1,000    → 4
+     1,000–10,000 → 6
+     10,000–100,000 → 8
+     > 100,000    → 10
+
+   Enter the number of workers:"
+```
+
+**WAIT for the user to respond.**
+
+{if non_forecastable_strategy == 'separate_job' and nf_local_models, ask in a separate question:}
+
+```
+AskUserQuestion:
+  "How many workers for the NF CPU cluster ({use_case}_nf_cpu_cluster)?
+
+   • Non-forecastable series: {n_nf_series}
+   • Recommended workers: {nf_recommended_workers}
+   • Instance type: same as main CPU cluster ({cpu_node_type})
+
+   Enter the number of workers:"
+```
+
+**WAIT for the user to respond.**
+
+#### Step 6b: GPU cluster configuration (if global or foundation models selected)
+
+```
+AskUserQuestion:
+  "GPU Cluster ({use_case}_gpu_cluster) — single-node, for global & foundation models:
+     • Runtime: 18.0.x-gpu-ml-scala2.13
+     • Workers: 0 (always single-node)
+
+   Which instance type?
+
+   {cloud-specific options for the user's provider only:}
+
+   AWS:
+   (a) g5.xlarge    — 1× A10G GPU, 24 GB  (small foundation models)
+   (b) g5.2xlarge   — 1× A10G GPU, 24 GB, more CPU/RAM
+   (c) g5.12xlarge  — 4× A10G GPUs, 96 GB  (recommended for global + foundation)
+   (d) g5.48xlarge  — 8× A10G GPUs, 192 GB (large-scale training)
+
+   Azure:
+   (a) Standard_NC4as_T4_v3    — 1× T4 GPU, 16 GB
+   (b) Standard_NC8as_T4_v3    — 1× T4 GPU, 16 GB, more CPU/RAM
+   (c) Standard_NV36ads_A10_v5 — 1× A10 GPU, 24 GB  (recommended)
+   (d) Standard_NV72ads_A10_v5 — 2× A10 GPUs, 48 GB (global + foundation)
+   (e) Standard_NC24ads_A100_v4 — 1× A100 GPU, 80 GB (large models)
+
+   GCP:
+   (a) g2-standard-4   — 1× L4 GPU, 24 GB
+   (b) g2-standard-8   — 1× L4 GPU, 24 GB, more CPU/RAM
+   (c) g2-standard-48  — 4× L4 GPUs, 96 GB  (recommended)
+   (d) a2-highgpu-1g   — 1× A100 GPU, 40 GB (large models)"
+```
+
+**WAIT for the user to respond.**
+
+{if non_forecastable_strategy == 'separate_job' and nf_gpu_models, ask in a separate question:}
+
+```
+AskUserQuestion:
+  "Which GPU instance for the NF GPU cluster ({use_case}_nf_gpu_cluster)?
+   A smaller instance is usually sufficient for non-forecastable series.
+
+   (select from the same GPU options above)"
+```
+
+**WAIT for the user to respond.**
 
 ### Decision logic
 
@@ -466,9 +490,9 @@ Each notebook installs MMF at the start:
 - **GPU models** (`run_gpu` notebook): Uses `subprocess.check_call` with model-specific install logic:
   - **Global (NeuralForecast)**: `mmf_sa[global] @ git+https://...@main`
   - **Foundation (Chronos)**: base `mmf_sa` + `chronos-forecasting==2.2.2` + `utilsforecast==0.2.15`
-  - **Foundation (TimesFM)**: base `mmf_sa` + `timesfm[torch]` from tarball URL + `utilsforecast==0.2.15`
+  - **Foundation (TimesFM)**: base `mmf_sa` + `timesfm[torch,xreg]` from tarball URL + `utilsforecast==0.2.15`
 
-> **Why subprocess for GPU?** `%pip` does not interpolate Python variables when the notebook is called via `dbutils.notebook.run()`. Additionally, `mmf_sa[foundation]` includes a transitive `timesfm @ git+https://...@commit` dependency whose `git checkout` fails on GPU clusters. The `run_gpu` template uses `subprocess.check_call` and installs `timesfm[torch]` from a GitHub tarball URL to bypass both issues.
+> **Why subprocess for GPU?** `%pip` does not interpolate Python variables when the notebook is called via `dbutils.notebook.run()`. Additionally, `mmf_sa[foundation]` includes a transitive `timesfm @ git+https://...@commit` dependency whose `git checkout` fails on GPU clusters. The `run_gpu` template uses `subprocess.check_call` and installs `timesfm[torch,xreg]` from a GitHub tarball URL to bypass both issues.
 
 ## Outputs
 

--- a/skills/databricks-skills/many-model-forecasting/3-provision-forecasting-resources.md
+++ b/skills/databricks-skills/many-model-forecasting/3-provision-forecasting-resources.md
@@ -159,13 +159,31 @@ Based on the model types and cloud provider, select from these configurations:
 | Setting | Value |
 |---------|-------|
 | **Runtime** | `17.3.x-cpu-ml-scala2.13` |
-| **Node type (AWS)** | `i3.xlarge` |
-| **Node type (Azure)** | `Standard_DS3_v2` |
-| **Node type (GCP)** | `n1-standard-4` |
-| **Workers** | Dynamic — see sizing logic below |
+| **Node type** | User-selectable — see CPU instance options below (default: 16 vCPU) |
+| **Workers** | **Always ask the user** — present sizing guideline as recommendation |
 | **Spark config** | `spark.sql.execution.arrow.enabled=true`, `spark.sql.adaptive.enabled=false`, `spark.databricks.delta.formatCheck.enabled=false`, `spark.databricks.delta.schema.autoMerge.enabled=true` |
 
-**CPU worker sizing logic:**
+**CPU instance options by cloud provider:**
+
+**AWS:**
+| Option | Instance | vCPUs | Memory | Notes |
+|--------|----------|-------|--------|-------|
+| **(a) recommended** | `i3.4xlarge` | 16 | 122 GB | Good balance of CPU and memory for most workloads |
+| (b) | `i3.8xlarge` | 32 | 244 GB | High-parallelism series fitting or very wide feature sets |
+
+**Azure:**
+| Option | Instance | vCPUs | Memory | Notes |
+|--------|----------|-------|--------|-------|
+| **(a) recommended** | `Standard_DS5_v2` | 16 | 56 GB | Good balance of CPU and memory for most workloads |
+| (b) | `Standard_D32ds_v5` | 32 | 128 GB | High-parallelism series fitting or very wide feature sets |
+
+**GCP:**
+| Option | Instance | vCPUs | Memory | Notes |
+|--------|----------|-------|--------|-------|
+| **(a) recommended** | `n1-standard-16` | 16 | 60 GB | Good balance of CPU and memory for most workloads |
+| (b) | `n1-standard-32` | 32 | 120 GB | High-parallelism series fitting or very wide feature sets |
+
+**CPU worker sizing — always ask the user:**
 
 Query the number of distinct series from the **correct** training table based on the non-forecastable strategy:
 ```sql
@@ -178,15 +196,41 @@ SELECT COUNT(DISTINCT unique_id) AS n_series
 FROM {catalog}.{schema}.{use_case}_train_data
 ```
 
-Suggest workers based on series count:
+Present the series count and the sizing guideline to the user, then **ask them to choose** the number of workers:
 
-| Series count | Suggested workers | Rationale |
+| Series count | Recommended workers | Rationale |
 |-------------|-------------------|-----------|
 | < 100 | 0 (single-node) | No parallelism needed |
 | 100 – 1,000 | 4 | Moderate parallelism |
 | 1,000 – 10,000 | 6 | Each worker handles ~1,500 series |
 | 10,000 – 100,000 | 8 | High parallelism for large-scale |
 | > 100,000 | 10 | Maximum recommended; beyond this consider partitioning |
+
+**⛔ Do NOT auto-apply the recommended value.** Always ask the user how many workers they want (showing the recommendation as guidance).
+
+#### Non-Forecastable CPU Cluster (`{use_case}_nf_cpu_cluster`) — for separate_job strategy, local models only
+
+Only created when `non_forecastable_strategy == 'separate_job'` and the non-forecastable models include local (CPU) models.
+
+Uses the same node type and instance selection as the main CPU cluster. Query the non-forecastable series count:
+
+```sql
+SELECT COUNT(DISTINCT unique_id) AS n_nf_series
+FROM {catalog}.{schema}.{use_case}_train_data_non_forecastable
+```
+
+Present the series count and the sizing guideline to the user, then **ask them to choose** the number of workers:
+
+| Non-forecastable series count | Recommended workers | Rationale |
+|------|-------------------|-----------|
+| < 100 | 0 (single-node) | No parallelism needed |
+| 100 – 1,000 | 2 | Light parallelism |
+| 1,000 – 10,000 | 4 | Moderate parallelism |
+| > 10,000 | 6 | Higher parallelism |
+
+**⛔ Do NOT auto-apply the recommended value.** Always ask the user how many workers they want (showing the recommendation as guidance).
+
+---
 
 #### GPU Cluster (`{use_case}_gpu_cluster`) — for global and foundation models
 
@@ -201,23 +245,32 @@ Suggest workers based on series count:
 | **Spark config** | `spark.master=local[*]`, `spark.databricks.cluster.profile=singleNode`, `spark.databricks.delta.formatCheck.enabled=false`, `spark.databricks.delta.schema.autoMerge.enabled=true` |
 | **custom_tags** | `{"ResourceClass": "SingleNode"}` |
 
-#### Non-Forecastable CPU Cluster (`{use_case}_nf_cpu_cluster`) — for separate_job strategy, local models only
+**GPU instance options by cloud provider:**
 
-Only created when `non_forecastable_strategy == 'separate_job'` and the non-forecastable models include local (CPU) models.
+**AWS:**
+| Option | Instance | GPUs | GPU Memory | Notes |
+|--------|----------|------|------------|-------|
+| (a) | `g5.xlarge` | 1× A10G | 24 GB | Small foundation models |
+| (b) | `g5.2xlarge` | 1× A10G | 24 GB | More CPU/RAM |
+| **(c) recommended** | `g5.12xlarge` | 4× A10G | 96 GB | Global + foundation |
+| (d) | `g5.48xlarge` | 8× A10G | 192 GB | Large-scale training |
 
-Uses the same node type as the main CPU cluster but with workers sized to the non-forecastable series count:
+**Azure:**
+| Option | Instance | GPUs | GPU Memory | Notes |
+|--------|----------|------|------------|-------|
+| (a) | `Standard_NC4as_T4_v3` | 1× T4 | 16 GB | Budget option |
+| (b) | `Standard_NC8as_T4_v3` | 1× T4 | 16 GB | More CPU/RAM |
+| **(c) recommended** | `Standard_NV36ads_A10_v5` | 1× A10 | 24 GB | Good balance |
+| (d) | `Standard_NV72ads_A10_v5` | 2× A10 | 48 GB | Global + foundation |
+| (e) | `Standard_NC24ads_A100_v4` | 1× A100 | 80 GB | Large models |
 
-```sql
-SELECT COUNT(DISTINCT unique_id) AS n_nf_series
-FROM {catalog}.{schema}.{use_case}_train_data_non_forecastable
-```
-
-| Non-forecastable series count | Suggested workers | Rationale |
-|------|-------------------|-----------|
-| < 100 | 0 (single-node) | No parallelism needed |
-| 100 – 1,000 | 2 | Light parallelism |
-| 1,000 – 10,000 | 4 | Moderate parallelism |
-| > 10,000 | 6 | Higher parallelism |
+**GCP:**
+| Option | Instance | GPUs | GPU Memory | Notes |
+|--------|----------|------|------------|-------|
+| (a) | `g2-standard-4` | 1× L4 | 24 GB | Small foundation models |
+| (b) | `g2-standard-8` | 1× L4 | 24 GB | More CPU/RAM |
+| **(c) recommended** | `g2-standard-48` | 4× L4 | 96 GB | Global + foundation |
+| (d) | `a2-highgpu-1g` | 1× A100 | 40 GB | Large models |
 
 #### Non-Forecastable GPU Cluster (`{use_case}_nf_gpu_cluster`) — for separate_job strategy, GPU models only
 
@@ -233,17 +286,42 @@ Present the computed configuration and let the user customize:
 AskUserQuestion:
   "Here is the proposed cluster configuration for your selected models:
 
-   ── MAIN PIPELINE (forecastable series: {n_forecastable}) ──
+   ── CPU CLUSTERS (local models) ──
 
    {if local models selected:
-   CPU Cluster ({use_case}_cpu_cluster):
+   Main CPU Cluster ({use_case}_cpu_cluster):
      • Runtime: 17.3.x-cpu-ml-scala2.13
-     • Node type: {cpu_node_type}
-     • Workers: {suggested_workers} (dataset has {n_series} forecastable series)
+     • Node type: (select one)
+
+     AWS:
+     (a) i3.4xlarge   — 16 vCPUs, 122 GB  (recommended)
+     (b) i3.8xlarge   — 32 vCPUs, 244 GB  (high-parallelism or wide features)
+
+     Azure:
+     (a) Standard_DS5_v2    — 16 vCPUs, 56 GB  (recommended)
+     (b) Standard_D32ds_v5  — 32 vCPUs, 128 GB (high-parallelism or wide features)
+
+     GCP:
+     (a) n1-standard-16 — 16 vCPUs, 60 GB  (recommended)
+     (b) n1-standard-32 — 32 vCPUs, 120 GB (high-parallelism or wide features)
+
+     • Forecastable series: {n_series}
+     • Recommended workers: {recommended_workers} (see sizing guide)
+     ❓ How many workers do you want for the CPU cluster?
+
+     {if non_forecastable_strategy == 'separate_job' and nf_local_models:
+     NF CPU Cluster ({use_case}_nf_cpu_cluster):
+       • Same node type as main CPU cluster
+       • Non-forecastable series: {n_nf_series}
+       • Recommended workers: {nf_recommended_workers} (see sizing guide)
+       ❓ How many workers do you want for the NF CPU cluster?
+     }
    }
 
+   ── GPU CLUSTERS (global & foundation models) — SINGLE NODE ──
+
    {if global or foundation models selected:
-   GPU Cluster ({use_case}_gpu_cluster) — SINGLE NODE:
+   Main GPU Cluster ({use_case}_gpu_cluster):
      • Runtime: 18.0.x-gpu-ml-scala2.13
      • Node type: (select one)
 
@@ -265,32 +343,23 @@ AskUserQuestion:
      (b) g2-standard-8   — 1× L4 GPU, 24 GB, more CPU/RAM
      (c) g2-standard-48  — 4× L4 GPUs, 96 GB  (recommended)
      (d) a2-highgpu-1g   — 1× A100 GPU, 40 GB (large models)
+
+     {if non_forecastable_strategy == 'separate_job' and nf_gpu_models:
+     NF GPU Cluster ({use_case}_nf_gpu_cluster):
+       • Same config as main GPU cluster — smaller instance usually sufficient
+       • Node type: (select from options above)
+     }
    }
 
    {if non_forecastable_strategy == 'separate_job':
-   ── NON-FORECASTABLE PIPELINE ({n_non_forecastable} series) ──
-
-     Models: {non_forecastable_models}
-
-     {if nf_local_models:
-     CPU Cluster ({use_case}_nf_cpu_cluster):
-       • Runtime: 17.3.x-cpu-ml-scala2.13
-       • Node type: {cpu_node_type}
-       • Workers: {nf_suggested_workers} (dataset has {n_nf_series} non-forecastable series)
-     }
-
-     {if nf_gpu_models:
-     GPU Cluster ({use_case}_nf_gpu_cluster) — SINGLE NODE:
-       • Runtime: 18.0.x-gpu-ml-scala2.13
-       • Node type: (select from options above — smaller instance usually sufficient)
-     }
+   Non-forecastable models: {non_forecastable_models}
    }
 
    Would you like to:
    (1) Accept the proposed configuration
-   (2) Change the CPU worker count(s)
+   (2) Change the CPU instance type or worker count
    (3) Select a different GPU instance type
-   (4) Change both
+   (4) Change both CPU and GPU configuration
    {if non_forecastable_strategy == 'separate_job':
    (5) Change non-forecastable cluster configuration}"
 ```
@@ -393,9 +462,9 @@ AskUserQuestion:
 
 Each notebook installs MMF at the start:
 
-- **Local models** (`run_local` notebook): Uses `%pip install "mmf_sa[local] @ git+https://...@v0.1.2"`
+- **Local models** (`run_local` notebook): Uses `%pip install "mmf_sa[local] @ git+https://...@main"`
 - **GPU models** (`run_gpu` notebook): Uses `subprocess.check_call` with model-specific install logic:
-  - **Global (NeuralForecast)**: `mmf_sa[global] @ git+https://...@v0.1.2`
+  - **Global (NeuralForecast)**: `mmf_sa[global] @ git+https://...@main`
   - **Foundation (Chronos)**: base `mmf_sa` + `chronos-forecasting==2.2.2` + `utilsforecast==0.2.15`
   - **Foundation (TimesFM)**: base `mmf_sa` + `timesfm[torch]` from tarball URL + `utilsforecast==0.2.15`
 

--- a/skills/databricks-skills/many-model-forecasting/4-execute-mmf-forecast.md
+++ b/skills/databricks-skills/many-model-forecasting/4-execute-mmf-forecast.md
@@ -165,14 +165,14 @@ Present all parameters to the user via `AskUserQuestion` for validation.
 | `static_features` | **Yes** — use when available | Constant per `group_id`, always known (e.g. `store_state`, `dept_id`) | `[]` |
 | `dynamic_historical_numerical` | **Yes** — for global models | Past-only; NOT needed at forecast time (e.g. lagged sales, rolling averages) | `[]` |
 | `dynamic_historical_categorical` | **Yes** — for global models | Past-only; NOT needed at forecast time | `[]` |
-| `dynamic_future_numerical` | **AVOID** | Must provide values for **every future `ds`** in the forecast horizon via a separate scoring table. If missing, the pipeline errors or **silently drops series**. | `[]` |
-| `dynamic_future_categorical` | **AVOID** | Same as above — requires known future values for every forecast date | `[]` |
+| `dynamic_future_numerical` | **Use only if Skill 1 created a scoring table** | Must provide values for **every future `ds`** in the forecast horizon via a scoring table. If missing, the pipeline errors or **silently drops series**. | `[]` |
+| `dynamic_future_categorical` | **Use only if Skill 1 created a scoring table** | Same as above — requires known future values for every forecast date | `[]` |
 
-> **Why avoid `dynamic_future_*`.** These features require the user to build and maintain a **scoring table** with one row per `unique_id` x future `ds`, pre-populated with the regressor values. Most many-series forecasting use cases (retail demand, financial metrics, IoT telemetry) do not have reliably known future regressors. When `dynamic_future_*` columns are specified but the scoring table is incomplete, `mmf_sa` either raises an error or silently removes the affected series from the forecast — producing no output for those series with no warning in the final results.
+> **When to use `dynamic_future_*`.** If Skill 1 created `{use_case}_scoring_data` with dynamic future regressors, use those column names here and set `{scoring_table}` to `{use_case}_scoring_data`. The scoring table was already validated in Skill 1 (coverage, NULLs, series completeness). If Skill 1 did NOT create a scoring table (user chose univariate mode or only static/historical regressors), always use `[]` for `dynamic_future_*` and `""` for `{scoring_table}`.
 >
-> **When `dynamic_future_*` is appropriate:** Only when the user's `{forecast_problem_brief}` explicitly mentions known future regressors (e.g., planned promotional calendars, contractual pricing schedules, weather forecasts) **and** the user confirms they have a pre-built scoring table. Even then, prefer `static_features` for attributes that are constant per series and `dynamic_historical_*` for signals derivable from past data.
+> **Warning:** When `dynamic_future_*` columns are specified but the scoring table is incomplete, `mmf_sa` either raises an error or silently removes the affected series from the forecast — producing no output for those series with no warning in the final results.
 
-**Always substitute `[]` for all `dynamic_future_*` placeholders and `""` for `{scoring_table}` unless the user explicitly requests future exogenous regressors and confirms they have a scoring table.**
+**Use `[]` for all `dynamic_future_*` placeholders and `""` for `{scoring_table}` unless Skill 1 created `{use_case}_scoring_data`.** If the scoring table exists, populate the `dynamic_future_*` lists from the column names carried forward from Skill 1 and set `{scoring_table}` to `{use_case}_scoring_data`.
 
 ### Step 3: Generate notebooks
 
@@ -202,11 +202,11 @@ Generate a single notebook from `mmf_local_notebook_template.ipynb` with all loc
 | `{target}` | `y` (default) |
 | `{use_case}` | use case name (for output table names and experiment path) |
 | `{static_features}` | Python list of column names constant per `group_id`, e.g. `[]` or `["dept_id","state_id"]`. Safe to use when available. |
-| `{dynamic_future_numerical}` | **AVOID — always `[]`** unless user has a scoring table with known future values. See [Feature type decision guide](#feature-type-decision-guide). |
-| `{dynamic_future_categorical}` | **AVOID — always `[]`**. Same as above. |
+| `{dynamic_future_numerical}` | `[]` unless Skill 1 created `{use_case}_scoring_data` with future numerical regressors. If so, use the column names from Skill 1 (e.g. `["planned_price", "temperature"]`). See [Feature type decision guide](#feature-type-decision-guide). |
+| `{dynamic_future_categorical}` | `[]` unless Skill 1 created `{use_case}_scoring_data` with future categorical regressors. If so, use the column names from Skill 1 (e.g. `["promo", "holiday"]`). |
 | `{dynamic_historical_numerical}` | Python list; past-only signals for **NeuralForecast** global models (e.g. lagged features), or `[]`. Safe to use. |
 | `{dynamic_historical_categorical}` | Python list, or `[]`. Safe to use. |
-| `{scoring_table}` | **Always `""`** unless `dynamic_future_*` is in use (not recommended). Empty string means `scoring_data` = `train_table`. |
+| `{scoring_table}` | `""` unless Skill 1 created `{use_case}_scoring_data`. If scoring table exists, set to `{use_case}_scoring_data`. Empty string means `scoring_data` = `train_table`. |
 
 Use the template from:
 - [mmf_local_notebook_template.ipynb](mmf_local_notebook_template.ipynb) → save locally as `notebooks/{use_case}/run_local.ipynb`
@@ -231,7 +231,7 @@ For each GPU model class (global and/or foundation), generate an **orchestrator 
 - Loops through the models and calls `run_gpu` for each via `dbutils.notebook.run()`
 - Each `dbutils.notebook.run()` invocation gets a fresh Python process, avoiding CUDA memory conflicts
 
-> **Why orchestrator + run_gpu.** PyTorch allocates CUDA memory that cannot be freed within the same Python process. Running multiple GPU models in sequence causes OOM when the second model loads. The `dbutils.notebook.run()` pattern gives each model a fresh kernel. This is the same pattern used in the [examples folder](../../examples/monthly/global_monthly.ipynb).
+> **Why orchestrator + run_gpu.** PyTorch allocates CUDA memory that cannot be freed within the same Python process. Running multiple GPU models in sequence causes OOM when the second model loads. The `dbutils.notebook.run()` pattern gives each model a fresh kernel. This is the same pattern used in the [examples folder](https://github.com/databricks-industry-solutions/many-model-forecasting/blob/main/examples/monthly/global_monthly.ipynb).
 
 ##### Placeholder values for orchestrator notebooks
 
@@ -252,11 +252,11 @@ For each GPU model class (global and/or foundation), generate an **orchestrator 
 | `{target}` | `y` (default) |
 | `{num_nodes}` | `1` (single-node always) |
 | `{static_features}` | Same as local notebook — Python list literal, often `[]`. Safe to use. |
-| `{dynamic_future_numerical}` | **AVOID — always `[]`** unless user has a scoring table. See [Feature type decision guide](#feature-type-decision-guide). |
-| `{dynamic_future_categorical}` | **AVOID — always `[]`**. Same as above. |
+| `{dynamic_future_numerical}` | `[]` unless Skill 1 created `{use_case}_scoring_data` with future numerical regressors. If so, use column names from Skill 1. See [Feature type decision guide](#feature-type-decision-guide). |
+| `{dynamic_future_categorical}` | `[]` unless Skill 1 created `{use_case}_scoring_data` with future categorical regressors. If so, use column names from Skill 1. |
 | `{dynamic_historical_numerical}` | Past-only signals for **global** models (lag/roll features), or `[]`. Safe to use. |
 | `{dynamic_historical_categorical}` | Same — often `[]`. Safe to use. |
-| `{scoring_table}` | **Always `""`** unless `dynamic_future_*` is in use (not recommended). |
+| `{scoring_table}` | `""` unless Skill 1 created `{use_case}_scoring_data`. If scoring table exists, set to `{use_case}_scoring_data`. |
 
 Use the template from:
 - [mmf_gpu_orchestrator_notebook_template.ipynb](mmf_gpu_orchestrator_notebook_template.ipynb)
@@ -306,7 +306,7 @@ run_forecast(
 
 #### Covariates and model coverage (reference)
 
-> **Default: univariate mode.** All model families work well without covariates. Always generate notebooks with `[]` for every covariate list and `""` for `scoring_table` unless the user explicitly requests otherwise. See [Feature type decision guide](#feature-type-decision-guide).
+> **Default: univariate mode.** All model families work well without covariates. Generate notebooks with `[]` for every covariate list and `""` for `scoring_table` unless Skill 1 configured exogenous regressors and created `{use_case}_scoring_data`. See [Feature type decision guide](#feature-type-decision-guide).
 
 `mmf_sa.run_forecast` maps columns into StatsForecast / NeuralForecast / Chronos / TimesFM pipelines:
 
@@ -314,7 +314,7 @@ run_forecast(
 - **NeuralForecast (global)**: benefits from **`static_features`** and **`dynamic_historical_*`** (past-only signals used during training). Can also accept `dynamic_future_*` but same caveat applies.
 - **Foundation (Chronos / TimesFM)**: benefits from **`static_features`**. Can accept `dynamic_future_*` in the current implementation but does not use `dynamic_historical_*`.
 
-**If the user insists on future exogenous regressors** (rare — only with confirmed known future data like promotional calendars), follow the pattern in [examples/run_external_regressors_daily.ipynb](../../examples/run_external_regressors_daily.ipynb): training table with history + target, a **separate** scoring table with future dates and exogenous columns, and set `{scoring_table}` accordingly.
+**If `{use_case}_scoring_data` exists from Skill 1**, set `{scoring_table}` to `{use_case}_scoring_data` and populate `dynamic_future_*` lists with the column names carried forward. The scoring table was already validated in Skill 1. See also [run_external_regressors_daily.ipynb](https://github.com/databricks-industry-solutions/many-model-forecasting/blob/main/examples/run_external_regressors_daily.ipynb) for the reference pattern.
 
 ### Step 4: Import notebooks into Databricks workspace
 

--- a/skills/databricks-skills/many-model-forecasting/4-execute-mmf-forecast.md
+++ b/skills/databricks-skills/many-model-forecasting/4-execute-mmf-forecast.md
@@ -265,6 +265,45 @@ Generate up to two orchestrators, saving locally:
 - `notebooks/{use_case}/orchestrator_global.ipynb` — if any global models selected
 - `notebooks/{use_case}/orchestrator_foundation.ipynb` — if any foundation models selected
 
+#### Frequency-specific configuration (automatic)
+
+`run_forecast` **automatically loads the correct frequency-specific YAML config** from the installed `mmf_sa` package based on the `freq` parameter. No explicit `conf` argument is needed in the generated notebooks.
+
+**Config resolution order (later overrides earlier):**
+
+1. **Base config** — auto-selected by `freq` from the `mmf_sa` package:
+   - `freq="H"` → `forecasting_conf_hourly.yaml` (`season_length: 24`, `window_size: 24`)
+   - `freq="D"` → `forecasting_conf_daily.yaml` (`season_length: 7`, `window_size: 7`)
+   - `freq="W"` → `forecasting_conf_weekly.yaml`
+   - `freq="M"` → `forecasting_conf_monthly.yaml` (`season_length: 12`, `window_size: 12`)
+2. **User `conf` kwarg** (optional) — a dict, YAML file path, or OmegaConf object merged on top of the base
+3. **Explicit keyword arguments** — `active_models`, `prediction_length`, `metric`, etc. override everything
+
+The base configs set `season_length` and `window_size` for models like `StatsForecastAutoArima`, `StatsForecastAutoETS`, `StatsForecastAutoTheta`, etc. The templates pass `freq` as a keyword argument, so the right config is loaded automatically — **do NOT pass `conf` in the generated notebooks**.
+
+The source YAML files live in the `mmf_sa` package directory (e.g., [`mmf_sa/forecasting_conf_daily.yaml`](https://github.com/databricks-industry-solutions/many-model-forecasting/blob/main/mmf_sa/forecasting_conf_daily.yaml)) and are bundled when `mmf_sa` is installed.
+
+**Advanced: overriding model hyperparameters.** If the user wants to tune `season_length` or other model-specific parameters, pass a `conf` dict to `run_forecast` that overrides only the desired keys. The base config's defaults still apply for everything else:
+
+```python
+custom_conf = {
+    "models": {
+        "StatsForecastAutoArima": {
+            "model_spec": {
+                "season_length": 52  # override for weekly with yearly seasonality
+            }
+        }
+    }
+}
+
+run_forecast(
+    ...,
+    conf=custom_conf,
+)
+```
+
+**Do NOT pass `conf` by default.** Only add it when the user explicitly requests hyperparameter tuning. The auto-selected base config is correct for the vast majority of use cases.
+
 #### Covariates and model coverage (reference)
 
 > **Default: univariate mode.** All model families work well without covariates. Always generate notebooks with `[]` for every covariate list and `""` for `scoring_table` unless the user explicitly requests otherwise. See [Feature type decision guide](#feature-type-decision-guide).

--- a/skills/databricks-skills/many-model-forecasting/5-post-process-and-evaluate.md
+++ b/skills/databricks-skills/many-model-forecasting/5-post-process-and-evaluate.md
@@ -370,8 +370,8 @@ Combined table of best forecasts for all series (forecastable + non-forecastable
 
 ## Deploy the Results Explorer App
 
-The `apps/` folder at the project root contains a ready-to-deploy **Dash** application
-("MMF Results Explorer") that lets the user interactively browse evaluation and
+The MMF repo contains a ready-to-deploy **Dash** application
+("MMF Results Explorer") in the [`apps/` folder](https://github.com/databricks-industry-solutions/many-model-forecasting/tree/main/apps) that lets the user interactively browse evaluation and
 scoring tables produced by the forecasting pipeline. It supports:
 
 - Selecting catalog, schema, training/evaluation/scoring tables from dropdowns
@@ -390,7 +390,17 @@ scoring tables produced by the forecasting pipeline. It supports:
 
 ### Deploy Steps
 
-Run the following CLI commands (replace `<your-email>` and `YOUR_PROFILE`):
+First, download the app files from the MMF repo. If the user has the full repo cloned, the files are at `apps/` in the project root. Otherwise, download them:
+
+```bash
+# Download the app files from GitHub (skip if full repo is cloned)
+mkdir -p apps
+curl -sL https://raw.githubusercontent.com/databricks-industry-solutions/many-model-forecasting/main/apps/app.py -o apps/app.py
+curl -sL https://raw.githubusercontent.com/databricks-industry-solutions/many-model-forecasting/main/apps/app.yaml -o apps/app.yaml
+curl -sL https://raw.githubusercontent.com/databricks-industry-solutions/many-model-forecasting/main/apps/requirements.txt -o apps/requirements.txt
+```
+
+Then run the following CLI commands (replace `<your-email>` and `YOUR_PROFILE`):
 
 ```bash
 # 1. Create the app resource
@@ -428,10 +438,10 @@ databricks apps deploy mmf-app \
 
 | File | Purpose |
 |------|---------|
-| `apps/app.py` | Dash application — layout, callbacks, SQL queries against evaluation/scoring/training tables |
-| `apps/app.yaml` | Databricks Apps manifest — sets the run command and binds the `sql-warehouse` resource |
-| `apps/requirements.txt` | Python dependencies (`dash-bootstrap-components`, `databricks-sql-connector`, `databricks-sdk`, `pandas`) |
-| `apps/README.md` | Detailed deploy/redeploy instructions and input reference |
+| [`apps/app.py`](https://github.com/databricks-industry-solutions/many-model-forecasting/blob/main/apps/app.py) | Dash application — layout, callbacks, SQL queries against evaluation/scoring/training tables |
+| [`apps/app.yaml`](https://github.com/databricks-industry-solutions/many-model-forecasting/blob/main/apps/app.yaml) | Databricks Apps manifest — sets the run command and binds the `sql-warehouse` resource |
+| [`apps/requirements.txt`](https://github.com/databricks-industry-solutions/many-model-forecasting/blob/main/apps/requirements.txt) | Python dependencies (`dash-bootstrap-components`, `databricks-sql-connector`, `databricks-sdk`, `pandas`) |
+| [`apps/README.md`](https://github.com/databricks-industry-solutions/many-model-forecasting/blob/main/apps/README.md) | Detailed deploy/redeploy instructions and input reference |
 
 ### How It Works
 

--- a/skills/databricks-skills/many-model-forecasting/SKILL.md
+++ b/skills/databricks-skills/many-model-forecasting/SKILL.md
@@ -181,6 +181,6 @@ Up to six separate jobs run **in parallel** — three for the main pipeline, plu
 ## MMF Installation
 
 Each generated notebook installs `mmf_sa` at the start:
-- Local: `pip install "mmf_sa[local] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@v0.1.2"`
-- Global: `pip install "mmf_sa[global] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@v0.1.2"`
-- Foundation: `pip install "mmf_sa[foundation] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@v0.1.2"`
+- Local: `pip install "mmf_sa[local] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@main"`
+- Global: `pip install "mmf_sa[global] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@main"`
+- Foundation: `pip install "mmf_sa[foundation] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@main"`

--- a/skills/databricks-skills/many-model-forecasting/mmf_gpu_run_notebook_template.ipynb
+++ b/skills/databricks-skills/many-model-forecasting/mmf_gpu_run_notebook_template.ipynb
@@ -10,7 +10,9 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "dbutils.widgets.text(\"catalog\", \"\")\n",
         "dbutils.widgets.text(\"schema\", \"\")\n",
@@ -37,13 +39,13 @@
         "dbutils.widgets.text(\"dynamic_historical_categorical\", \"\")\n",
         "# Scoring table: always blank unless dynamic_future_* is in use (not recommended).\n",
         "dbutils.widgets.text(\"scoring_table\", \"\")"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "import subprocess, sys\n",
         "\n",
@@ -51,14 +53,14 @@
         "is_global = \"NeuralForecast\" in model_name\n",
         "is_timesfm = \"TimesFM\" in model_name\n",
         "\n",
-        "MMF_GIT = \"mmf_sa @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@v0.1.2\"\n",
+        "MMF_GIT = \"mmf_sa @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@main\"\n",
         "TIMESFM_TARBALL = \"https://github.com/google-research/timesfm/archive/2dcc66fbfe2155adba1af66aa4d564a0ee52f61e.tar.gz\"\n",
         "\n",
         "def pip(*args):\n",
         "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", *args, \"--quiet\"])\n",
         "\n",
         "if is_global:\n",
-        "    pip(f\"mmf_sa[global] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@v0.1.2\")\n",
+        "    pip(f\"mmf_sa[global] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@main\")\n",
         "elif is_timesfm:\n",
         "    pip(MMF_GIT)\n",
         "    pip(f\"timesfm[torch] @ {TIMESFM_TARBALL}\")\n",
@@ -68,13 +70,13 @@
         "    pip(\"chronos-forecasting==2.2.2\", \"utilsforecast==0.2.15\")\n",
         "\n",
         "dbutils.library.restartPython()"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "def _parse_col_list(s):\n",
         "    if not s or not str(s).strip():\n",
@@ -103,13 +105,13 @@
         "dynamic_future_categorical = _parse_col_list(dbutils.widgets.get(\"dynamic_future_categorical\"))\n",
         "dynamic_historical_numerical = _parse_col_list(dbutils.widgets.get(\"dynamic_historical_numerical\"))\n",
         "dynamic_historical_categorical = _parse_col_list(dbutils.widgets.get(\"dynamic_historical_categorical\"))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "import warnings\n",
         "import logging\n",
@@ -167,9 +169,7 @@
         "    num_nodes=num_nodes,\n",
         "    **_exog_kwargs(),\n",
         ")"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
   ],
   "metadata": {

--- a/skills/databricks-skills/many-model-forecasting/mmf_gpu_run_notebook_template.ipynb
+++ b/skills/databricks-skills/many-model-forecasting/mmf_gpu_run_notebook_template.ipynb
@@ -63,7 +63,7 @@
         "    pip(f\"mmf_sa[global] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@main\")\n",
         "elif is_timesfm:\n",
         "    pip(MMF_GIT)\n",
-        "    pip(f\"timesfm[torch] @ {TIMESFM_TARBALL}\")\n",
+        "    pip(f\"timesfm[torch,xreg] @ {TIMESFM_TARBALL}\")\n",
         "    pip(\"utilsforecast==0.2.15\")\n",
         "else:\n",
         "    pip(MMF_GIT)\n",

--- a/skills/databricks-skills/many-model-forecasting/mmf_local_notebook_template.ipynb
+++ b/skills/databricks-skills/many-model-forecasting/mmf_local_notebook_template.ipynb
@@ -10,25 +10,27 @@
     },
     {
       "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "%pip install \"mmf_sa[local] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@v0.1.2\" --quiet"
-      ],
       "execution_count": null,
-      "outputs": []
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install \"mmf_sa[local] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git@main\" --quiet"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "%restart_python"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "catalog = \"{catalog}\"\n",
         "schema = \"{schema}\"\n",
@@ -55,13 +57,36 @@
         "dynamic_historical_categorical = {dynamic_historical_categorical}\n",
         "# Scoring table: always \"\" (same as train_table) unless dynamic_future_* is in use (not recommended).\n",
         "scoring_table = \"{scoring_table}\""
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
+      "source": [
+        "n_series = spark.sql(\n",
+        "    \"SELECT COUNT(DISTINCT \" + group_id + \") AS n FROM \" + catalog + \".\" + schema + \".\" + train_table\n",
+        ").collect()[0][\"n\"]\n",
+        "\n",
+        "n_cores = sc.defaultParallelism\n",
+        "partitions = min(n_series, n_cores * 2)\n",
+        "\n",
+        "current = spark.conf.get(\"spark.sql.shuffle.partitions\")\n",
+        "current_val = int(current) if current != \"auto\" else 200\n",
+        "\n",
+        "if partitions > current_val:\n",
+        "    spark.conf.set(\"spark.sql.shuffle.partitions\", str(partitions))\n",
+        "    print(\"Set spark.sql.shuffle.partitions to \" + str(partitions) + \" (series=\" + str(n_series) + \", cores=\" + str(n_cores) + \")\")\n",
+        "else:\n",
+        "    print(\"Keeping spark.sql.shuffle.partitions at \" + str(current_val) + \" (series=\" + str(n_series) + \", cores=\" + str(n_cores) + \")\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
       "source": [
         "import warnings\n",
         "import logging\n",
@@ -116,9 +141,7 @@
         "    use_case_name=\"{use_case}\",\n",
         "    **_exog_kwargs(),\n",
         ")"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
   ],
   "metadata": {

--- a/skills/install.py
+++ b/skills/install.py
@@ -30,6 +30,8 @@ SKILL_FILES = [
     "mmf_gpu_run_notebook_template.ipynb",
     "mmf_gpu_orchestrator_notebook_template.ipynb",
     "mmf_profiling_notebook_template.ipynb",
+    "mmf_prep_notebook_template.ipynb",
+    "mmf_post_process_notebook_template.ipynb",
 ]
 MARKER = "<!-- mmf-dev-kit:skills -->"
 ALL_TOOLS = ["claude", "cursor", "gemini"]
@@ -51,6 +53,8 @@ Read these files to learn the patterns before starting any forecasting task:
 - `databricks-skills/many-model-forecasting/mmf_gpu_run_notebook_template.ipynb` — GPU single-model runner (static, uses widgets)
 - `databricks-skills/many-model-forecasting/mmf_gpu_orchestrator_notebook_template.ipynb` — GPU orchestrator (loops models via dbutils.notebook.run)
 - `databricks-skills/many-model-forecasting/mmf_profiling_notebook_template.ipynb` — profiling notebook template
+- `databricks-skills/many-model-forecasting/mmf_prep_notebook_template.ipynb` — data prep reproducibility notebook (generated after Skill 1)
+- `databricks-skills/many-model-forecasting/mmf_post_process_notebook_template.ipynb` — post-processing reproducibility notebook (generated after Skill 5)
 """
 
 CURSOR_RULE_CONTENT = """\
@@ -75,6 +79,8 @@ Read these files to learn the patterns before starting any forecasting task:
 - `databricks-skills/many-model-forecasting/mmf_gpu_run_notebook_template.ipynb` — GPU single-model runner (static, uses widgets)
 - `databricks-skills/many-model-forecasting/mmf_gpu_orchestrator_notebook_template.ipynb` — GPU orchestrator (loops models via dbutils.notebook.run)
 - `databricks-skills/many-model-forecasting/mmf_profiling_notebook_template.ipynb` — profiling notebook template
+- `databricks-skills/many-model-forecasting/mmf_prep_notebook_template.ipynb` — data prep reproducibility notebook (generated after Skill 1)
+- `databricks-skills/many-model-forecasting/mmf_post_process_notebook_template.ipynb` — post-processing reproducibility notebook (generated after Skill 5)
 """
 
 


### PR DESCRIPTION
## Add MMF Skill: End-to-End Many-Model Forecasting Pipeline

### Summary

- Implements a complete 5-skill MMF pipeline (Prep & Clean Data → Profile & Classify Series → Provision Resources → Execute Forecast → Post-Process & Evaluate) orchestrated via interactive agent workflow
- Adds notebook templates for local CPU models, GPU model runner, GPU orchestrator, series profiling, data prep, and post-processing — all with placeholder-based generation for reproducibility
- Updates skill documentation (Skills 1, 3, 4, 5) and GPU run/orchestrator notebook templates to support exogenous regressors (static features, dynamic future/historical) with safety guidance

### Test plan

- [x] Validated end-to-end on Rossmann dataset (1,000 stores, daily frequency, 10-day horizon, 4 dynamic future regressors)
- [x] Ran 35 models (17 local, 10 global, 8 foundation) across 3 parallel Databricks jobs
- [x] Confirmed 104,895 evaluation rows (35 models x 999 series x 3 backtest windows) written to Unity Catalog
- [x] Best-model selection produced 941 series with valid sMAPE (overall avg 10.15%)
- [x] AutoARIMA won 41% of series; 21 distinct models won at least one series
- [x] All reproducibility notebooks uploaded and verified in Databricks workspace
- [x] GPU OOM on g5.xlarge handled by automatic retry on g5.2xlarge
- [x] Duplicate evaluation rows from re-run deduplicated successfully