### PR TITLE
Improve MMF skill for generic agent compatibility (Claude Code + Genie Code)

### DIFF
--- a/skills/assistant_instructions.md
+++ b/skills/assistant_instructions.md
@@ -1,0 +1,41 @@
+## Role & Purpose
+
+You are a **Time Series Forecasting Assistant** built on Databricks Genie Code. Your primary job is to guide users through end-to-end Many Model Forecasting (MMF) projects on Databricks — from data preparation and series profiling, through cluster provisioning and pipeline execution, to post-processing and evaluation.
+
+### Core Responsibilities
+- Walk the user through the full MMF workflow interactively, respecting decision gates at every step
+- Discover, clean, and prepare time series data for forecasting at scale
+- Profile and classify series to recommend appropriate model families (statistical, neural, foundation)
+- Provision CPU and GPU compute resources tailored to the workload
+- Generate production-ready notebooks, create Databricks Jobs, and orchestrate parallel forecast runs
+- Evaluate results, select best models per series, and produce business-ready summaries
+- Leverage the `mmf_sa` solution accelerator and Databricks-native tools (Unity Catalog, MLflow, Jobs)
+
+### Secondary Capabilities
+- General Databricks workspace assistance (SQL queries, data exploration, notebook authoring)
+- Dashboard creation and data visualization
+- Pipeline and job management guidance
+
+## Agent Memories
+
+### Skill Execution — Mandatory Rules
+- **ALWAYS follow skill STOP gates.** When a skill marks a step as `STOP GATE`, you MUST pause and ask the user before proceeding. Never assume, skip, or auto-fill answers to STOP gate questions.
+- **Read the full skill file before taking any action.** Do not start executing steps until you have read both SKILL.md and the relevant sub-skill file completely.
+- **Never assume workspace paths, folder names, or project locations.** Always ask the user where to store assets.
+- **Never assume cloud provider, cluster config, or parameters.** Ask each STOP gate question individually and wait for the user's response.
+- **If a skill says "WAIT for the user to respond" — stop and wait.** Do not batch multiple STOP gate questions together or proceed with defaults.
+
+### MMF / Forecasting — CRITICAL
+- **Whenever the user asks ANYTHING related to MMF, Many Model Forecasting, forecasting, or time series**, the FIRST action — before exploring data, writing code, or executing anything — MUST be:
+  1. Read the full `SKILL.md` at `.assistant/skills/many-model-forecasting/SKILL.md`
+  2. Read the specific sub-skill file for the step being requested (e.g., `3-provision-forecasting-resources.md`, `4-execute-mmf-forecast.md`)
+  3. Follow every STOP gate in those files without exception
+- **Do NOT skip this even if you think you already know how to do it.** The skill files contain the user's exact workflow, templates, and decision points. Ignoring them is unacceptable.
+
+### User Context
+- Workspace: your Databricks workspace URL (e.g. https://your-workspace.cloud.databricks.com)
+- Email: your-email@your-domain.com
+
+### Communication Preferences
+- **Never display "⛔ STOP GATE" text in responses.** Still follow all stop gates internally (pause and ask the user), but do not show the literal "⛔ STOP GATE" label in the conversation. Keep the questions natural and conversational.
+- User prefers Spanish occasionally — respond in the language the user uses.

--- a/skills/databricks-skills/many-model-forecasting/1-prep-and-clean-data.md
+++ b/skills/databricks-skills/many-model-forecasting/1-prep-and-clean-data.md
@@ -1,5 +1,7 @@
 # Prep and Clean Data
 
+> ⛔ **MANDATORY:** If you have not read [SKILL.md](SKILL.md) yet, read it now before proceeding. Do NOT take any action until you have read both SKILL.md and this file in full.
+
 **Slash command:** `/prep-and-clean-data`
 
 Asks the user for catalog, schema, use case name, and a **forecast problem brief** (`{forecast_problem_brief}`), connects to a Databricks workspace,
@@ -75,6 +77,29 @@ AskUserQuestion:
 ```
 
 Store a normalized **3–6 line** summary as `{forecast_problem_brief}`. Carry it in the conversation through all downstream skills (reconfirm in Skill 2 if context is missing).
+
+### ⛔ STOP GATE — Step 0c: Confirm project folder
+
+Call `get_current_user()` to obtain `{full_email}`. Then ask:
+
+```
+AskUserQuestion:
+  "Where would you like to store the notebooks for this project?
+
+   (a) Use an existing folder — provide the folder name (e.g. 'my-project')
+   (b) Create a new folder — provide a name and I will create /Users/{full_email}/{name}/notebooks/
+   (c) Use default — I will create /Users/{full_email}/{use_case}/notebooks/
+
+  Options: [free text — user picks (a), (b), or (c) and provides a name if needed]"
+```
+
+**WAIT for the user to respond. Do NOT create any folders or notebooks until the user answers.**
+
+Set:
+- `{project_folder}` = user-provided name, or `{use_case}` if they pick (c)
+- `{notebook_base_path}` = `/Users/{full_email}/{project_folder}/notebooks`
+
+**Carry `{project_folder}` and `{notebook_base_path}` through all subsequent skills.**
 
 #### Optional research and deep documentation
 

--- a/skills/databricks-skills/many-model-forecasting/2-profile-and-classify-series.md
+++ b/skills/databricks-skills/many-model-forecasting/2-profile-and-classify-series.md
@@ -1,5 +1,7 @@
 # Profile and Classify Series (OPTIONAL)
 
+> ⛔ **MANDATORY:** If you have not read [SKILL.md](SKILL.md) yet, read it now before proceeding. Do NOT take any action until you have read both SKILL.md and this file in full.
+
 **Slash command:** `/profile-and-classify-series`
 
 **This skill is optional.** If the user skips it, they manually select models in Skill 3.
@@ -44,6 +46,9 @@ The profiling involves STL decomposition, ADF tests, and spectral analysis per s
 | `{freq}` | detected or user-specified frequency |
 | `{prediction_length}` | user-specified forecast horizon (integer) |
 | `{forecast_problem_brief}` | from Skill 1 conversation context, or collected at Step 2 if missing |
+| `{username}` | current user (without `@domain`) — from `get_current_user()` |
+| `{project_folder}` | user's project folder name — asked in Step 2b (default: `{use_case}`) |
+| `{notebook_base_path}` | `/Users/{full_email}/{project_folder}/notebooks` — derived from `get_current_user()` + user choice |
 
 Use the template from:
 - [mmf_profiling_notebook_template.ipynb](mmf_profiling_notebook_template.ipynb)
@@ -93,6 +98,31 @@ AskUserQuestion:
 
 **Do NOT proceed until the user confirms.**
 
+### Step 2b: Get current user and project folder
+
+Call `get_current_user()` to obtain `{full_email}` and derive `{username}` (local part before `@`).
+
+If `{project_folder}` and `{notebook_base_path}` were already confirmed in Skill 1, reuse them. If not known (new session or Skill 1 was skipped), ask:
+
+```
+AskUserQuestion:
+  "Where would you like to store the notebooks for this project?
+
+   (a) Use an existing folder — provide the folder name (e.g. 'my-project')
+   (b) Create a new folder — provide a name and I will create /Users/{full_email}/{name}/notebooks/
+   (c) Use default — I will create /Users/{full_email}/{use_case}/notebooks/
+
+  Options: [free text — user picks (a), (b), or (c) and provides a name if needed]"
+```
+
+**WAIT for the user to respond. Do NOT create any folders or upload any notebooks until the user answers.**
+
+Set:
+- `{project_folder}` = user-provided name, or `{use_case}` if they pick (c)
+- `{notebook_base_path}` = `/Users/{full_email}/{project_folder}/notebooks`
+
+Store these for use in all subsequent steps.
+
 ### Step 3: Generate notebook from template
 
 **CRITICAL: Copy the template VERBATIM from `mmf_profiling_notebook_template.ipynb`, only replacing the `{placeholder}` tokens with actual values. Do NOT add, remove, or modify any other code.**
@@ -109,47 +139,81 @@ Save the filled-in notebook locally as `/tmp/{use_case}_run_profiling.ipynb`.
 
 ### Step 4: Import notebook into Databricks workspace
 
-> ⚠️ **Do NOT use `upload_file` for notebooks.** The `upload_file` MCP tool creates a workspace FILE, not a NOTEBOOK. Databricks job tasks require a proper NOTEBOOK object. Using `upload_file` will cause the job to fail immediately with: `'<path>' is not a notebook`.
+The notebook **must** be imported as a proper NOTEBOOK object (not a FILE). Databricks job tasks require this — a FILE will cause the job to fail immediately with: `'<path>' is not a notebook`.
 
-Use the **Databricks CLI** to import the notebook with `JUPYTER` format:
+Use the method available in your environment:
 
+**External agent (Claude Code, Cursor, Copilot, etc.) — Databricks CLI:**
 ```bash
-databricks workspace import /notebooks/{use_case}/run_profiling \
+databricks workspace import {notebook_base_path}/run_profiling \
   --file /tmp/{use_case}_run_profiling.ipynb \
   --format JUPYTER \
   --overwrite
 ```
+> ⚠️ Do NOT use the `upload_file` MCP tool — it creates a FILE, not a NOTEBOOK.
 
-If the path already exists as a FILE (e.g. from a prior failed `upload_file`), delete it first:
-
+If the path already exists as a FILE (e.g. from a prior failed upload), delete it first:
 ```bash
-databricks workspace delete /notebooks/{use_case}/run_profiling
-databricks workspace import /notebooks/{use_case}/run_profiling \
+databricks workspace delete {notebook_base_path}/run_profiling
+databricks workspace import {notebook_base_path}/run_profiling \
   --file /tmp/{use_case}_run_profiling.ipynb \
   --format JUPYTER
 ```
 
-### Step 4b: Verify notebook type
+**Genie Code (Databricks-native) — Python SDK:**
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.workspace import ImportFormat
+import base64
 
-After import, confirm the workspace object is a NOTEBOOK (not a FILE):
-
-```bash
-databricks workspace get-status /notebooks/{use_case}/run_profiling
+w = WorkspaceClient()
+with open("/tmp/{use_case}_run_profiling.ipynb", "rb") as f:
+    content = base64.b64encode(f.read()).decode("utf-8")
+w.workspace.import_(
+    path="{notebook_base_path}/run_profiling",
+    format=ImportFormat.JUPYTER,
+    overwrite=True,
+    content=content
+)
 ```
 
-The returned `object_type` **must** be `NOTEBOOK`. If it is `FILE`, the job will fail — delete and re-import with `--format JUPYTER` before proceeding.
+### Step 4b: Verify notebook type
+
+After import, confirm the workspace object is a NOTEBOOK (not a FILE).
+
+**External agent — Databricks CLI:**
+```bash
+databricks workspace get-status {notebook_base_path}/run_profiling
+```
+
+**Genie Code — Python SDK:**
+```python
+obj = w.workspace.get_status(path="{notebook_base_path}/run_profiling")
+print(obj.object_type)  # must be NOTEBOOK
+```
+
+The returned `object_type` **must** be `NOTEBOOK`. If it is `FILE`, the job will fail — delete and re-import before proceeding.
 
 ### Step 5: Create Workflow job on serverless compute
 
-Create a single-task Workflow job on **serverless compute** (profiling is CPU-bound and benefits from instant startup):
+Job name: `{use_case}_profiling_{username}` (no date — one persistent job per user, upsert approach).
+
+**Upsert:** search for an existing job with that exact name owned by `{full_email}`. If found → update it. If not found → create it.
+
+Create a single-task Workflow job on **serverless compute** (profiling benefits from instant startup):
 
 ```json
 {
-  "name": "{use_case}_profiling",
+  "name": "{use_case}_profiling_{username}",
+  "description": "MMF profiling | use_case={use_case} | catalog={catalog}.{schema} | created={YYYYMMDD}",
+  "tags": {
+    "aidevkit_project": "mmf-agent",
+    "created_by": "databricks-ai-dev-kit"
+  },
   "tasks": [{
     "task_key": "profile_series",
     "notebook_task": {
-      "notebook_path": "notebooks/{use_case}/run_profiling"
+      "notebook_path": "{notebook_base_path}/run_profiling"
     },
     "environment_key": "Default"
   }],

--- a/skills/databricks-skills/many-model-forecasting/3-provision-forecasting-resources.md
+++ b/skills/databricks-skills/many-model-forecasting/3-provision-forecasting-resources.md
@@ -1,5 +1,7 @@
 # Provision Forecasting Resources
 
+> ⛔ **MANDATORY:** If you have not read [SKILL.md](SKILL.md) yet, read it now before proceeding. Do NOT take any action until you have read both SKILL.md and this file in full.
+
 **Slash command:** `/provision-forecasting-resources`
 
 Asks the user which models to run, determines required cluster types, asks the
@@ -133,24 +135,15 @@ If `non_forecastable_strategy` is `include` or `fallback`, skip this step entire
 Ask the user which cloud provider the workspace runs on: **AWS**, **Azure**, or **GCP**.
 This determines the specific node types.
 
-### Step 4: Check existing clusters
+<!-- 
+  NOTE — Step 4 (Check existing clusters) removed.
+  MMF jobs always use ephemeral job clusters defined in the Workflow spec (Skill 4).
+  There is no scenario in the normal flow where an existing all-purpose cluster needs to be listed or reused.
+  `list_clusters` was previously called here but returns 300k+ chars in shared workspaces with no actionable result.
+  PENDING: validate with the team whether there is a legitimate reuse scenario that requires this step.
+-->
 
-Use MCP `list_clusters` to find clusters matching the required configurations:
-- Match by runtime version (`17.3.x-cpu-ml-scala2.13` for CPU, `18.0.x-gpu-ml-scala2.13` for GPU)
-- Match by node type for the target cloud provider
-
-Decision logic:
-```
-if matching_cluster.state == "RUNNING":
-    → "Found running cluster {name}. Reuse it?"
-elif matching_cluster.state == "TERMINATED":
-    → "Found terminated cluster {name}. Start it?"
-    → Use start_cluster MCP tool if confirmed
-else:
-    → Proceed to generate ephemeral job cluster config
-```
-
-### Step 5: Select cluster configuration
+### Step 4: Select cluster configuration
 
 Based on the model types and cloud provider, select from these configurations:
 

--- a/skills/databricks-skills/many-model-forecasting/4-execute-mmf-forecast.md
+++ b/skills/databricks-skills/many-model-forecasting/4-execute-mmf-forecast.md
@@ -1,5 +1,7 @@
 # Execute MMF Forecast
 
+> ⛔ **MANDATORY:** If you have not read [SKILL.md](SKILL.md) yet, read it now before proceeding. Do NOT take any action until you have read both SKILL.md and this file in full.
+
 **Slash command:** `/execute-mmf-forecast`
 
 Validates parameters, asks the user about backtesting setup, generates notebooks
@@ -58,6 +60,33 @@ Based on the strategy, determine which training table to use for the **main pipe
 | `separate_job` | `{use_case}_train_data_forecastable` | Separate job created in Step 5a below |
 
 Set `{train_table}` to the correct table name for all subsequent notebook generation steps.
+
+### ⛔ STOP GATE — Step 0b: Get current user and confirm project folder
+
+Call `get_current_user()` to obtain the authenticated user's full email (e.g. `user@databricks.com`). Derive:
+- `{username}` = local part before `@` (e.g. `user`)
+- `{YYYYMMDD}` = today's date (e.g. `20260420`)
+
+If `{project_folder}` and `{notebook_base_path}` were already confirmed in Skill 1, reuse them. If not known (new session or Skill 1 was skipped), ask:
+
+```
+AskUserQuestion:
+  "Where would you like to store the notebooks for this project?
+
+   (a) Use an existing folder — provide the folder name (e.g. 'my-project')
+   (b) Create a new folder — provide a name and I will create /Users/{full_email}/{name}/notebooks/
+   (c) Use default — I will create /Users/{full_email}/{use_case}/notebooks/
+
+  Options: [free text — user picks (a), (b), or (c) and provides a name if needed]"
+```
+
+**WAIT for the user to respond. Do NOT create any folders or upload any notebooks until the user answers.**
+
+Set:
+- `{project_folder}` = user-provided name, or `{use_case}` if they pick (c)
+- `{notebook_base_path}` = `/Users/{full_email}/{project_folder}/notebooks`
+
+Store these for use in all subsequent steps (notebook paths, job names, tags).
 
 ### Step 1: Pre-flight parameter validation
 
@@ -318,45 +347,104 @@ run_forecast(
 
 ### Step 4: Import notebooks into Databricks workspace
 
-> ⚠️ **Do NOT use `upload_file` for notebooks.** The `upload_file` MCP tool creates a workspace FILE, not a NOTEBOOK. Databricks job tasks require a proper NOTEBOOK object. Using `upload_file` will cause every job to fail immediately with: `'<path>' is not a notebook`.
+The notebooks **must** be imported as proper NOTEBOOK objects (not FILEs). Databricks job tasks require this — a FILE will cause every job to fail immediately with: `'<path>' is not a notebook`.
 
-Use the **Databricks CLI** with `--format JUPYTER` to import each notebook. If a path already exists as a FILE from a prior failed `upload_file`, delete it first before importing.
+Use the method available in your environment:
 
-Import all notebooks:
+**External agent (Claude Code, Cursor, Copilot, etc.) — Databricks CLI:**
 
 ```bash
 # Local models notebook
-databricks workspace import /notebooks/{use_case}/run_local \
+databricks workspace import {notebook_base_path}/run_local \
   --file /tmp/{use_case}_run_local.ipynb \
   --format JUPYTER --overwrite
 
 # GPU run notebook (static — uploaded verbatim)
-databricks workspace import /notebooks/{use_case}/run_gpu \
+databricks workspace import {notebook_base_path}/run_gpu \
   --file /tmp/{use_case}_run_gpu.ipynb \
   --format JUPYTER --overwrite
 
 # Global orchestrator (if global models selected)
-databricks workspace import /notebooks/{use_case}/orchestrator_global \
+databricks workspace import {notebook_base_path}/orchestrator_global \
   --file /tmp/{use_case}_orchestrator_global.ipynb \
   --format JUPYTER --overwrite
 
 # Foundation orchestrator (if foundation models selected)
-databricks workspace import /notebooks/{use_case}/orchestrator_foundation \
+databricks workspace import {notebook_base_path}/orchestrator_foundation \
   --file /tmp/{use_case}_orchestrator_foundation.ipynb \
   --format JUPYTER --overwrite
+```
+> ⚠️ Do NOT use the `upload_file` MCP tool — it creates a FILE, not a NOTEBOOK. If a path already exists as a FILE from a prior failed upload, delete it first before importing.
+
+**Genie Code (Databricks-native) — Python SDK:**
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.workspace import ImportFormat
+import base64
+
+w = WorkspaceClient()
+
+notebooks = {
+    "run_local": "/tmp/{use_case}_run_local.ipynb",
+    "run_gpu": "/tmp/{use_case}_run_gpu.ipynb",
+    "orchestrator_global": "/tmp/{use_case}_orchestrator_global.ipynb",      # if global models selected
+    "orchestrator_foundation": "/tmp/{use_case}_orchestrator_foundation.ipynb",  # if foundation models selected
+}
+
+for name, local_path in notebooks.items():
+    with open(local_path, "rb") as f:
+        content = base64.b64encode(f.read()).decode("utf-8")
+    w.workspace.import_(
+        path=f"{notebook_base_path}/{name}",
+        format=ImportFormat.JUPYTER,
+        overwrite=True,
+        content=content
+    )
 ```
 
 ### Step 4b: Verify all notebooks imported correctly
 
+**External agent — Databricks CLI:**
 ```bash
-databricks workspace list /notebooks/{use_case}/
+databricks workspace list {notebook_base_path}/
+```
+
+**Genie Code — Python SDK:**
+```python
+for item in w.workspace.list(path="{notebook_base_path}/"):
+    print(item.path, item.object_type)
 ```
 
 Confirm every path shows `object_type: NOTEBOOK` (not `FILE`). Fix any mismatches before creating jobs.
 
 The local copies in `notebooks/{use_case}/` serve as version-controllable artifacts of the generated pipeline.
 
-### Step 5: Create one job per model class (triggered in parallel)
+### Step 5: Upsert one job per model class
+
+Job names follow the pattern `{use_case}_{type}_forecasting_{username}` (no date — one persistent job per type per user):
+- Local: `{use_case}_local_forecasting_{username}`
+- Global: `{use_case}_global_forecasting_{username}`
+- Foundation: `{use_case}_foundation_forecasting_{username}`
+
+For each model class selected, **upsert** the job:
+1. Search for an existing job with that exact name owned by `{full_email}`
+2. If found → **update** it with the new notebook path and cluster config
+3. If not found → **create** it
+
+This ensures there is always exactly one job per type per user — no accumulation of stale jobs.
+
+> ⚠️ **One job per model class — no exceptions.** Do NOT combine model classes into a single multi-task job. Local, global, and foundation models require different compute (CPU vs GPU) and must run independently in parallel.
+
+---
+
+### Step 5b: Create one job per model class (triggered in parallel)
+
+> ⚠️ **One job per model class — no exceptions.** Do NOT combine model classes into a single multi-task job. Create separate jobs for local, global, and foundation models. This is required for correct cluster assignment (CPU vs GPU) and independent parallelism.
+
+All jobs must include:
+- `tags`: `{ "mmf-agent": "", "databricks-ai-dev-kit": "" }`
+- `description`: human-readable summary — e.g. `"MMF {type} forecasting | use_case={use_case} | catalog={catalog}.{schema} | models={active_models} | horizon={prediction_length} | created={YYYYMMDD}"`
 
 **Create separate Workflow jobs for each model class and trigger them all in parallel.** This maximizes throughput — local models run on CPU while GPU models run concurrently.
 
@@ -364,11 +452,16 @@ The local copies in `notebooks/{use_case}/` serve as version-controllable artifa
 
 ```json
 {
-  "name": "{use_case}_local_forecasting",
+  "name": "{use_case}_local_forecasting_{username}",
+  "description": "MMF local forecasting | use_case={use_case} | catalog={catalog}.{schema} | models={active_local_models} | horizon={prediction_length} | created={YYYYMMDD}",
+  "tags": {
+    "aidevkit_project": "mmf-agent",
+    "created_by": "databricks-ai-dev-kit"
+  },
   "tasks": [{
     "task_key": "local_models",
     "notebook_task": {
-      "notebook_path": "notebooks/{use_case}/run_local"
+      "notebook_path": "{notebook_base_path}/run_local"
     },
     "job_cluster_key": "{use_case}_cpu_cluster"
   }],
@@ -394,11 +487,16 @@ The local copies in `notebooks/{use_case}/` serve as version-controllable artifa
 
 ```json
 {
-  "name": "{use_case}_global_forecasting",
+  "name": "{use_case}_global_forecasting_{username}",
+  "description": "MMF global forecasting | use_case={use_case} | catalog={catalog}.{schema} | models={active_global_models} | horizon={prediction_length} | created={YYYYMMDD}",
+  "tags": {
+    "aidevkit_project": "mmf-agent",
+    "created_by": "databricks-ai-dev-kit"
+  },
   "tasks": [{
     "task_key": "global_models",
     "notebook_task": {
-      "notebook_path": "notebooks/{use_case}/orchestrator_global"
+      "notebook_path": "{notebook_base_path}/orchestrator_global"
     },
     "job_cluster_key": "{use_case}_gpu_cluster"
   }],
@@ -427,11 +525,16 @@ The local copies in `notebooks/{use_case}/` serve as version-controllable artifa
 
 ```json
 {
-  "name": "{use_case}_foundation_forecasting",
+  "name": "{use_case}_foundation_forecasting_{username}",
+  "description": "MMF foundation forecasting | use_case={use_case} | catalog={catalog}.{schema} | models={active_foundation_models} | horizon={prediction_length} | created={YYYYMMDD}",
+  "tags": {
+    "aidevkit_project": "mmf-agent",
+    "created_by": "databricks-ai-dev-kit"
+  },
   "tasks": [{
     "task_key": "foundation_models",
     "notebook_task": {
-      "notebook_path": "notebooks/{use_case}/orchestrator_foundation"
+      "notebook_path": "{notebook_base_path}/orchestrator_foundation"
     },
     "job_cluster_key": "{use_case}_gpu_cluster"
   }],

--- a/skills/databricks-skills/many-model-forecasting/5-post-process-and-evaluate.md
+++ b/skills/databricks-skills/many-model-forecasting/5-post-process-and-evaluate.md
@@ -1,5 +1,7 @@
 # Post-Process and Evaluate
 
+> ⛔ **MANDATORY:** If you have not read [SKILL.md](SKILL.md) yet, read it now before proceeding. Do NOT take any action until you have read both SKILL.md and this file in full.
+
 **Slash command:** `/post-process-and-evaluate`
 
 Calculates multiple accuracy metrics, performs best-model selection per series,
@@ -33,6 +35,28 @@ AskUserQuestion:
 ```
 
 **Do NOT proceed until the user provides catalog, schema, and use case name.**
+
+### Step 0a-ii: Confirm project folder
+
+Call `get_current_user()` to obtain `{full_email}`.
+
+If `{project_folder}` and `{notebook_base_path}` were already confirmed in a previous skill, reuse them. If not known, ask:
+
+```
+AskUserQuestion:
+  "Where are the project notebooks stored?
+
+   (a) Use an existing folder — provide the folder name (e.g. 'my-project')
+   (b) Use default — /Users/{full_email}/{use_case}/notebooks/
+
+  Options: [free text — user picks (a) or (b)]"
+```
+
+**WAIT for the user to respond.**
+
+Set:
+- `{project_folder}` = user-provided name, or `{use_case}` if they pick (b)
+- `{notebook_base_path}` = `/Users/{full_email}/{project_folder}/notebooks`
 
 ### Step 0a: Read non-forecastable strategy from pipeline config
 

--- a/skills/databricks-skills/many-model-forecasting/SKILL.md
+++ b/skills/databricks-skills/many-model-forecasting/SKILL.md
@@ -5,6 +5,9 @@ description: "Kickstart Many Models Forecasting (MMF) projects on Databricks —
 
 # Many Models Forecasting (MMF)
 
+> ⛔ **MANDATORY — Read before taking any action.**
+> Before doing anything in an MMF project — querying data, creating resources, generating notebooks, or running jobs — read this file completely. Then identify which skill the user needs and read that skill file in full before proceeding. Do NOT act on user instructions until you have read the relevant skill file.
+
 ## Overview
 
 Automates the full [Many Models Forecasting](https://github.com/databricks-industry-solutions/many-model-forecasting) workflow on Databricks. Five skills walk you through data preparation, series profiling, cluster setup, pipeline execution, and post-evaluation interactively using Databricks MCP tools and `AskUserQuestion`.
@@ -177,6 +180,8 @@ Up to six separate jobs run **in parallel** — three for the main pipeline, plu
 - Databricks MCP server configured
 - A Databricks workspace with time series data
 - Unity Catalog access to the target catalog/schema
+- **Skill files uploaded** to `/Workspace/Users/{your_email}/.assistant/skills/many-model-forecasting/`
+- **Assistant instructions configured** at `/Workspace/Users/{your_email}/.assistant_instructions.md` — this file is loaded automatically by Genie Code at the start of every conversation. It should include instructions to always read the MMF skill files before taking any action, and to respect all STOP gates. Without this file, the agent may ignore skill instructions and proceed autonomously.
 
 ## MMF Installation
 


### PR DESCRIPTION
## Summary

This PR improves the MMF skill to work reliably with any external AI coding agent (Claude Code, Cursor, GitHub Copilot) as well as Databricks Genie Code.

### Key changes

- **STOP gate compliance** — Restructured all STOP gates to ask for information the agent cannot infer (labeled `(a)/(b)/(c)` options + `Options: [free text]` + explicit prohibition). Agents were previously bypassing gates by confirming their own decisions instead of waiting for user input.
- **Project folder prompt** — Added Step 0c to Skill 1 to ask for the project folder *after* the use case description is known, so the default name is meaningful. Skills 2, 4, and 5 inherit `{project_folder}` from context or ask only if unknown.
- **Job upsert pattern** — Replaced the job-reuse lookup (fragile) with a simple upsert: job name = `{use_case}_{type}_forecasting_{username}` (no date). One persistent job per model class per user. Search by exact name, update if found, create if not.
- **Notebook upload** — Added dual-path instructions for notebook upload: Databricks CLI for external agents, Python SDK (`WorkspaceClient`) for Genie Code.
- **Job tags** — Standardized across all skills: `aidevkit_project: mmf-agent`, `created_by: databricks-ai-dev-kit`.
- **Profiling job alignment** — Skill 2 profiling job now follows the same naming, tagging, and description conventions as the forecast jobs in Skills 4–5.
- **`⛔ MANDATORY` headers** — Added to every skill file and `SKILL.md` so agents are explicitly told to read the full file before acting.
- **`assistant_instructions.md`** — New file added to `skills/`. Provides a workspace-level system prompt for Genie Code that enforces skill loading and STOP gate compliance at conversation start.

### Files changed

| File | Change |
|------|--------|
| `skills/many-model-forecasting/SKILL.md` | Added mandatory read header; noted `assistant_instructions.md` setup |
| `skills/many-model-forecasting/1-prep-and-clean-data.md` | Reordered Step 0 (problem brief before folder prompt); STOP gate for project folder |
| `skills/many-model-forecasting/2-profile-and-classify-series.md` | Inherits project folder; dual-path notebook upload; profiling job aligned to Skills 4–5 pattern |
| `skills/many-model-forecasting/3-provision-forecasting-resources.md` | Removed `list_clusters` step (ephemeral clusters; pending team validation) |
| `skills/many-model-forecasting/4-execute-mmf-forecast.md` | Upsert job pattern; dual-path notebook upload; one-job-per-model-class enforcement |
| `skills/many-model-forecasting/5-post-process-and-evaluate.md` | Inherits project folder; mandatory header |
| `skills/assistant_instructions.md` | New — workspace system prompt for Genie Code agents |

## Test plan

- [ ] Skill 1: agent asks for use case description first, then project folder (with `(a)/(b)/(c)` options)
- [ ] Skill 2: agent inherits project folder from Skill 1 context
- [ ] Skill 4: agent asks for job name before creating/updating; does not create combined multi-task jobs
- [ ] Skills 4–5: job tags match `aidevkit_project: mmf-agent` / `created_by: databricks-ai-dev-kit`
- [ ] External agent (Claude Code): notebook upload via Databricks CLI
- [ ] Genie Code: notebook upload via `WorkspaceClient`

This pull request was AI-assisted by Isaac.