### PR TITLE
fixed serverless foundation model timestamp issue

### DIFF
--- a/examples/serverless/foundation_serverless.ipynb
+++ b/examples/serverless/foundation_serverless.ipynb
@@ -18,7 +18,7 @@
       "source": [
         "# Many Models Forecasting Demo (foundation models on serverless GPU)\n",
         "\n",
-        "This notebook runs MMF foundation models on a Databricks serverless GPU compute (AI Runtime, env v5), using the [M4 competition](https://www.sciencedirect.com/science/article/pii/S0169207019301128#sec5) monthly data. Most descriptions mirror the [classic-cluster monthly notebook](https://github.com/databricks-industry-solutions/many-model-forecasting/blob/main/examples/monthly/foundation_monthly.ipynb), so we focus only on the serverless-specific parts.\n",
+        "This notebook runs MMF foundation models on a Databricks serverless GPU compute (Base Environment Standard v5), using the [M4 competition](https://www.sciencedirect.com/science/article/pii/S0169207019301128#sec5) monthly data. Most descriptions mirror the [classic-cluster monthly notebook](https://github.com/databricks-industry-solutions/many-model-forecasting/blob/main/examples/monthly/foundation_monthly.ipynb), so we focus only on the serverless-specific parts.\n",
         "\n",
         "> **`serverless=True` flag.** MMF foundation models normally distribute inference via `pandas_udf`, which on Databricks serverless compute runs on Spark Connect Python workers. Those workers are CPU-only even when the driver has a GPU, so the distributed predict path cannot use the GPU on serverless. Setting `serverless=True` in `run_forecast` switches Chronos and TimesFM to a driver-only predict path. The trade-off vs the distributed path is no multi-GPU data parallelism — all series go through one GPU."
       ]

--- a/examples/serverless/global_serverless_dl.ipynb
+++ b/examples/serverless/global_serverless_dl.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "### Serverless Compute setup\n",
     "\n",
-    "Attach this notebook to a [serverless compute](https://docs.databricks.com/aws/en/compute/serverless/notebooks). Then go to the [Configuration](https://docs.databricks.com/aws/en/compute/serverless/dependencies) tab. Choose `A10` (GPU) in [Accelerator](https://docs.databricks.com/aws/en/compute/serverless/gpu) section and set the [Environment version](https://docs.databricks.com/aws/en/compute/serverless/dependencies#-select-an-environment-version) to Standard v4. In the Dependencies section, [add the path](https://docs.databricks.com/aws/en/compute/serverless/dependencies#create-common-utilities-to-share-across-your-workspace) to your `many-model-forecasting` directory: e.g., `/Workspace/Users/ryuta.yoshimatsu@databricks.com/many-model-forecasting`. This is required to use the MMF functions within the notebooks."
+    "Attach this notebook to a [serverless compute](https://docs.databricks.com/aws/en/compute/serverless/notebooks). Then go to the [Configuration](https://docs.databricks.com/aws/en/compute/serverless/dependencies) tab. Choose `A10` (GPU) in [Accelerator](https://docs.databricks.com/aws/en/compute/serverless/gpu) section and set the [Environment version](https://docs.databricks.com/aws/en/compute/serverless/dependencies#-select-an-environment-version) to Standard v5. In the Dependencies section, [add the path](https://docs.databricks.com/aws/en/compute/serverless/dependencies#create-common-utilities-to-share-across-your-workspace) to your `many-model-forecasting` directory: e.g., `/Workspace/Users/ryuta.yoshimatsu@databricks.com/many-model-forecasting`. This is required to use the MMF functions within the notebooks."
    ]
   },
   {

--- a/examples/serverless/global_serverless_ml.ipynb
+++ b/examples/serverless/global_serverless_ml.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "### Serverless Compute setup\n",
     "\n",
-    "Attach this notebook to a [serverless compute](https://docs.databricks.com/aws/en/compute/serverless/notebooks). Then go to the [Configuration](https://docs.databricks.com/aws/en/compute/serverless/dependencies) tab and set the [Environment version](https://docs.databricks.com/aws/en/compute/serverless/dependencies#-select-an-environment-version) to Standard v4. In the Dependencies section, [add the path](https://docs.databricks.com/aws/en/compute/serverless/dependencies#create-common-utilities-to-share-across-your-workspace) to your `many-model-forecasting` directory: e.g., `/Workspace/Users/ryuta.yoshimatsu@databricks.com/many-model-forecasting`. This is required to use the MMF functions within the notebooks."
+    "Attach this notebook to a [serverless compute](https://docs.databricks.com/aws/en/compute/serverless/notebooks). Then go to the [Configuration](https://docs.databricks.com/aws/en/compute/serverless/dependencies) tab and set the [Environment version](https://docs.databricks.com/aws/en/compute/serverless/dependencies#-select-an-environment-version) to Standard v5. In the Dependencies section, [add the path](https://docs.databricks.com/aws/en/compute/serverless/dependencies#create-common-utilities-to-share-across-your-workspace) to your `many-model-forecasting` directory: e.g., `/Workspace/Users/ryuta.yoshimatsu@databricks.com/many-model-forecasting`. This is required to use the MMF functions within the notebooks."
    ]
   },
   {

--- a/examples/serverless/local_univariate_serverless.ipynb
+++ b/examples/serverless/local_univariate_serverless.ipynb
@@ -41,7 +41,7 @@
    "source": [
     "### Serverless Compute setup\n",
     "\n",
-    "Attach this notebook to a [serverless compute](https://docs.databricks.com/aws/en/compute/serverless/notebooks). Then go to the [Configuration](https://docs.databricks.com/aws/en/compute/serverless/dependencies) tab and set the [Environment version](https://docs.databricks.com/aws/en/compute/serverless/dependencies#-select-an-environment-version) to 4. In the Dependencies section, [add the path](https://docs.databricks.com/aws/en/compute/serverless/dependencies#create-common-utilities-to-share-across-your-workspace) to your `many-model-forecasting` directory: e.g., `/Workspace/Users/ryuta.yoshimatsu@databricks.com/many-model-forecasting`. This is required to use the MMF functions within the notebooks."
+    "Attach this notebook to a [serverless compute](https://docs.databricks.com/aws/en/compute/serverless/notebooks). Then go to the [Configuration](https://docs.databricks.com/aws/en/compute/serverless/dependencies) tab and set the [Environment version](https://docs.databricks.com/aws/en/compute/serverless/dependencies#-select-an-environment-version) to Standard v5. In the Dependencies section, [add the path](https://docs.databricks.com/aws/en/compute/serverless/dependencies#create-common-utilities-to-share-across-your-workspace) to your `many-model-forecasting` directory: e.g., `/Workspace/Users/ryuta.yoshimatsu@databricks.com/many-model-forecasting`. This is required to use the MMF functions within the notebooks."
    ]
   },
   {

--- a/mmf_sa/Forecaster.py
+++ b/mmf_sa/Forecaster.py
@@ -657,6 +657,13 @@ class Forecaster:
             .agg(
                 collect_list(self.conf["date_col"]).alias(self.conf["date_col"]),
                 collect_list(self.conf["target"]).alias(self.conf["target"]))
+        # Defensive: align with score_local_model's explicit ArrayType(TimestampType())
+        # so the scoring_output table schema stays consistent across all writers,
+        # even if a future global model wrapper changes its predict() return shape.
+        sdf = sdf.withColumn(
+            self.conf["date_col"],
+            sdf[self.conf["date_col"]].cast(ArrayType(TimestampType())),
+        )
         (
             sdf.withColumn(self.conf["group_id"], col(self.conf["group_id"]).cast(StringType()))
             .withColumn("model", lit(model_conf["name"]))
@@ -701,6 +708,12 @@ class Forecaster:
                     lambda arr: np.asarray(arr, dtype="datetime64[us]")
                 )
         sdf = self.spark.createDataFrame(prediction_df).drop('index')
+        # Normalize the date column to TIMESTAMP (LTZ) so the schema matches the
+        # table created by score_local_model (which uses ArrayType(TimestampType())).
+        # No-op on classic compute (already LTZ); applies NTZ -> LTZ on Spark Connect,
+        # where Arrow inference of object-dtype columns containing numpy datetime64
+        # arrays produces array<timestamp_ntz> and would otherwise fail Delta merge.
+        sdf = sdf.withColumn(date_col, sdf[date_col].cast(ArrayType(TimestampType())))
         (
             sdf.withColumn(self.conf["group_id"], col(self.conf["group_id"]).cast(StringType()))
             .withColumn("model", lit(model_conf["name"]))


### PR DESCRIPTION
## Fix Delta schema-merge failure when running `foundation_serverless` after other serverless writers

### Summary
- Fix `[DELTA_FAILED_TO_MERGE_FIELDS] Failed to merge fields 'ds' and 'ds'.` raised by `score_foundation_model` when it appends to a `scoring_output` Delta table that was created by another writer on serverless (Spark Connect) compute.
- Align the four serverless example notebooks on Base Environment Standard v5.

### Root cause
`Forecaster.score_foundation_model` writes a pandas DataFrame whose `ds` column is `object`-dtype (each cell is a `numpy.ndarray[datetime64[us]]`) and lets Spark infer the schema in `createDataFrame`. The inference resolves to a *different* Spark type on the two runtimes:

| Runtime                    | Path                                                                                              | Inferred `ds` type       |
| -------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------ |
| Classic (`pyspark.sql`)    | Arrow fast-path can't handle object column → falls back to Python `_infer_type` → `TimestampType` | `array<timestamp>` (LTZ) |
| Serverless (Spark Connect) | No Python fallback. `pyarrow.Table.from_pandas` infers `list<timestamp[us]>` with no tz info      | `array<timestamp_ntz>`   |

The other two writers in `Forecaster.py` are immune by construction:
- `score_local_model` passes an **explicit** `StructType` containing `ArrayType(TimestampType())`, so inference is bypassed.
- `score_global_model` operates on a *scalar* `datetime64[ns]` pandas Series (not an object column), so both runtimes take the same Arrow fast path and produce LTZ; `collect_list` then wraps it as `array<timestamp>`.

Once `local_univariate_serverless` (or any prior LTZ writer) seeds the Delta table with `ds: array<timestamp>`, the foundation writer on Spark Connect appends `ds: array<timestamp_ntz>` and Delta refuses to merge the two. The issue is invisible on classic compute because the Python-fallback path happens to land on LTZ as well — not because the code is correct.

### Changes

**`mmf_sa/Forecaster.py`**
- **`score_foundation_model` (the actual fix):** add one cast immediately after `createDataFrame` to normalize `ds` to `ArrayType(TimestampType())` (LTZ). On classic compute the column is already LTZ, so the cast is a no-op. On Spark Connect, it performs the documented NTZ → LTZ conversion using the session timezone, so the append matches the existing Delta schema.
- **`score_global_model` (defensive):** apply the same cast after `collect_list`. This is not required to fix the current bug, but it locks the column type to `array<timestamp>` regardless of any future change in a global model wrapper's `predict()` return shape, preventing the same bear-trap from coming back.

No new imports were needed; `ArrayType` and `TimestampType` were already imported at the top of `Forecaster.py`.

**`examples/serverless/*.ipynb`**
- Updated the "Serverless Compute setup" markdown in all four serverless notebooks to consistently specify **Base Environment Standard v5**, since v5 is required by `foundation_serverless` (AI Runtime / A10) and the other three work on v5 as well.

### Why this fix
- **Minimal blast radius.** A single one-line cast at the exact site where the type diverges, instead of rewriting the predict-return shape or adding a full explicit `StructType` (which would need to mirror, and stay in sync with, every column the foundation predict path emits).
- **No-op on the runtime that already works.** Classic compute keeps writing LTZ exactly as before; nothing observable changes.
- **Same pattern as `score_local_model`.** Consistent across all three writers (`local`, `global`, `foundation`) — all of them now produce `array<timestamp>` (LTZ) deterministically, regardless of runtime.

### Test plan
1. Drop existing example output tables (optional — only needed to redo a clean run): `mmf.m4.serverless_scoring_output`, `mmf.m4.serverless_evaluation_output`.
2. Run the four notebooks in order on **Standard v5**:
   - `examples/serverless/local_univariate_serverless.ipynb`
   - `examples/serverless/global_serverless_ml.ipynb`
   - `examples/serverless/global_serverless_dl.ipynb`
   - `examples/serverless/foundation_serverless.ipynb`
3. Verify each notebook completes scoring (no `DELTA_FAILED_TO_MERGE_FIELDS`).
4. Verify the resulting table schema is consistent:
   ```python
   spark.table("mmf.m4.serverless_scoring_output").printSchema()
   # ds should be array<timestamp> (LTZ), not array<timestamp_ntz>
   ```
5. Spot-check the contents of the table:
   ```sql
   SELECT model, count(*) FROM mmf.m4.serverless_scoring_output GROUP BY model;
   ```
6. Re-run the same four notebooks on **classic compute** to confirm no regression (the cast is a no-op there).

### Risk / backward compatibility
- Existing Delta tables created by previous releases are `array<timestamp>` (LTZ); the patched writers continue to produce LTZ, so no migration is required.
- If a user has a `scoring_output` table that was created from a *failed* serverless run with mixed schemas, they may need to drop or recreate it once — but this PR does not introduce any new schema mismatch.