### PR TITLE
Add FreshRetailNet serverless MMF example

### DIFF
--- a/examples/fresh_retail_net/01_fresh_retail_net_data_prep.ipynb
+++ b/examples/fresh_retail_net/01_fresh_retail_net_data_prep.ipynb
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -89,16 +89,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Collecting datasets\n  Downloading datasets-5.0.0-py3-none-any.whl (555 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 555.1/555.1 kB 7.6 MB/s eta 0:00:00\nRequirement already satisfied: pandas in /databricks/python3/lib/python3.10/site-packages (from datasets) (1.5.3)\nCollecting huggingface-hub<2.0,>=0.25.0\n  Downloading huggingface_hub-1.19.0-py3-none-any.whl (693 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 693.4/693.4 kB 13.3 MB/s eta 0:00:00\nCollecting fsspec[http]<=2026.4.0,>=2023.1.0\n  Downloading fsspec-2026.4.0-py3-none-any.whl (203 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 203.4/203.4 kB 12.6 MB/s eta 0:00:00\nRequirement already satisfied: numpy>=1.17 in /databricks/python3/lib/python3.10/site-packages (from datasets) (1.23.5)\nCollecting requests>=2.32.2\n  Downloading requests-2.34.2-py3-none-any.whl (73 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 73.1/73.1 kB 11.3 MB/s eta 0:00:00\nCollecting xxhash\n  Downloading xxhash-3.7.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (193 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 193.3/193.3 kB 12.0 MB/s eta 0:00:00\nRequirement already satisfied: filelock in /databricks/python3/lib/python3.10/site-packages (from datasets) (3.16.1)\nCollecting httpx<1.0.0\n  Downloading httpx-0.28.1-py3-none-any.whl (73 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 73.5/73.5 kB 10.6 MB/s eta 0:00:00\nRequirement already satisfied: packaging in /databricks/python3/lib/python3.10/site-packages (from datasets) (23.2)\nCollecting pyarrow>=21.0.0\n  Downloading pyarrow-24.0.0-cp310-cp310-manylinux_2_28_x86_64.whl (48.8 MB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB 47.5 MB/s eta 0:00:00\nCollecting tqdm>=4.66.3\n  Downloading tqdm-4.68.2-py3-none-any.whl (78 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 78.6/78.6 kB 8.6 MB/s eta 0:00:00\nCollecting dill<0.4.2,>=0.3.0\n  Downloading dill-0.4.1-py3-none-any.whl (120 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 120.0/120.0 kB 15.1 MB/s eta 0:00:00\nCollecting multiprocess<0.70.20\n  Downloading multiprocess-0.70.19-py310-none-any.whl (134 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 134.9/134.9 kB 19.6 MB/s eta 0:00:00\nCollecting pyyaml>=5.1\n  Downloading pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (770 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 770.3/770.3 kB 74.4 MB/s eta 0:00:00\nCollecting aiohttp!=4.0.0a0,!=4.0.0a1\n  Downloading aiohttp-3.14.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (1.7 MB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.7/1.7 MB 81.6 MB/s eta 0:00:00\nCollecting httpcore==1.*\n  Downloading httpcore-1.0.9-py3-none-any.whl (78 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 78.8/78.8 kB 11.5 MB/s eta 0:00:00\nRequirement already satisfied: idna in /databricks/python3/lib/python3.10/site-packages (from httpx<1.0.0->datasets) (3.4)\nRequirement already satisfied: anyio in /databricks/python3/lib/python3.10/site-packages (from httpx<1.0.0->datasets) (3.5.0)\nRequirement already satisfied: certifi in /databricks/python3/lib/python3.10/site-packages (from httpx<1.0.0->datasets) (2022.12.7)\nCollecting h11>=0.16\n  Downloading h11-0.16.0-py3-none-any.whl (37 kB)\nCollecting typer<0.26.0,>=0.20.0\n  Downloading typer-0.25.1-py3-none-any.whl (58 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 58.4/58.4 kB 9.8 MB/s eta 0:00:00\nRequirement already satisfied: typing-extensions>=4.1.0 in /databricks/python3/lib/python3.10/site-packages (from huggingface-hub<2.0,>=0.25.0->datasets) (4.4.0)\nCollecting hf-xet<2.0.0,>=1.5.1\n  Downloading hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (4.5 MB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.5/4.5 MB 114.9 MB/s eta 0:00:00\nCollecting click>=8.4.0\n  Downloading click-8.4.1-py3-none-any.whl (116 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 116.6/116.6 kB 20.5 MB/s eta 0:00:00\nCollecting certifi\n  Downloading certifi-2026.5.20-py3-none-any.whl (134 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 134.1/134.1 kB 23.1 MB/s eta 0:00:00\nRequirement already satisfied: urllib3<3,>=1.26 in /databricks/python3/lib/python3.10/site-packages (from requests>=2.32.2->datasets) (1.26.14)\nRequirement already satisfied: charset_normalizer<4,>=2 in /databricks/python3/lib/python3.10/site-packages (from requests>=2.32.2->datasets) (2.0.4)\nRequirement already satisfied: python-dateutil>=2.8.1 in /databricks/python3/lib/python3.10/site-packages (from pandas->datasets) (2.8.2)\nRequirement already satisfied: pytz>=2020.1 in /databricks/python3/lib/python3.10/site-packages (from pandas->datasets) (2022.7)\nCollecting aiohappyeyeballs>=2.5.0\n  Downloading aiohappyeyeballs-2.6.2-py3-none-any.whl (15 kB)\nCollecting aiosignal>=1.4.0\n  Downloading aiosignal-1.4.0-py3-none-any.whl (7.5 kB)\nCollecting frozenlist>=1.1.1\n  Downloading frozenlist-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl (219 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 219.5/219.5 kB 25.2 MB/s eta 0:00:00\nCollecting multidict<7.0,>=4.5\n  Downloading multidict-6.7.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (243 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 243.3/243.3 kB 26.1 MB/s eta 0:00:00\nCollecting propcache>=0.2.0\n  Downloading propcache-0.5.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (60 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.1/60.1 kB 9.0 MB/s eta 0:00:00\nCollecting yarl<2.0,>=1.17.0\n  Downloading yarl-1.24.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (106 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 106.7/106.7 kB 18.0 MB/s eta 0:00:00\nRequirement already satisfied: attrs>=17.3.0 in /databricks/python3/lib/python3.10/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.4.0,>=2023.1.0->datasets) (22.1.0)\nCollecting async-timeout<6.0,>=4.0\n  Downloading async_timeout-5.0.1-py3-none-any.whl (6.2 kB)\nRequirement already satisfied: six>=1.5 in /usr/lib/python3/dist-packages (from python-dateutil>=2.8.1->pandas->datasets) (1.16.0)\nCollecting rich>=13.8.0\n  Downloading rich-15.0.0-py3-none-any.whl (310 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 310.7/310.7 kB 38.4 MB/s eta 0:00:00\nCollecting shellingham>=1.3.0\n  Downloading shellingham-1.5.4-py2.py3-none-any.whl (9.8 kB)\nCollecting annotated-doc>=0.0.2\n  Downloading annotated_doc-0.0.4-py3-none-any.whl (5.3 kB)\nRequirement already satisfied: sniffio>=1.1 in /databricks/python3/lib/python3.10/site-packages (from anyio->httpx<1.0.0->datasets) (1.2.0)\nCollecting pygments<3.0.0,>=2.13.0\n  Downloading pygments-2.20.0-py3-none-any.whl (1.2 MB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 80.2 MB/s eta 0:00:00\nCollecting markdown-it-py>=2.2.0\n  Downloading markdown_it_py-4.2.0-py3-none-any.whl (91 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 91.7/91.7 kB 16.5 MB/s eta 0:00:00\nCollecting mdurl~=0.1\n  Downloading mdurl-0.1.2-py3-none-any.whl (10.0 kB)\nInstalling collected packages: xxhash, tqdm, shellingham, pyyaml, pygments, pyarrow, propcache, multidict, mdurl, hf-xet, h11, fsspec, frozenlist, dill, click, certifi, async-timeout, annotated-doc, aiohappyeyeballs, yarl, requests, multiprocess, markdown-it-py, httpcore, aiosignal, rich, httpx, aiohttp, typer, huggingface-hub, datasets\n  Attempting uninstall: pygments\n    Found existing installation: Pygments 2.11.2\n    Not uninstalling pygments at /databricks/python3/lib/python3.10/site-packages, outside environment /local_disk0/.ephemeral_nfs/envs/pythonEnv-50c76149-60f9-4139-96ee-9021617427f0\n    Can't uninstall 'Pygments'. No files were found to uninstall.\n  Attempting uninstall: pyarrow\n    Found existing installation: pyarrow 8.0.0\n    Not uninstalling pyarrow at /databricks/python3/lib/python3.10/site-packages, outside environment /local_disk0/.ephemeral_nfs/envs/pythonEnv-50c76149-60f9-4139-96ee-9021617427f0\n    Can't uninstall 'pyarrow'. No files were found to uninstall.\n  Attempting uninstall: click\n    Found existing installation: click 8.0.4\n    Not uninstalling click at /databricks/python3/lib/python3.10/site-packages, outside environment /local_disk0/.ephemeral_nfs/envs/pythonEnv-50c76149-60f9-4139-96ee-9021617427f0\n    Can't uninstall 'click'. No files were found to uninstall.\n  Attempting uninstall: certifi\n    Found existing installation: certifi 2022.12.7\n    Not uninstalling certifi at /databricks/python3/lib/python3.10/site-packages, outside environment /local_disk0/.ephemeral_nfs/envs/pythonEnv-50c76149-60f9-4139-96ee-9021617427f0\n    Can't uninstall 'certifi'. No files were found to uninstall.\n  Attempting uninstall: requests\n    Found existing installation: requests 2.28.1\n    Not uninstalling requests at /databricks/python3/lib/python3.10/site-packages, outside environment /local_disk0/.ephemeral_nfs/envs/pythonEnv-50c76149-60f9-4139-96ee-9021617427f0\n    Can't uninstall 'requests'. No files were found to uninstall.\nSuccessfully installed aiohappyeyeballs-2.6.2 aiohttp-3.14.1 aiosignal-1.4.0 annotated-doc-0.0.4 async-timeout-5.0.1 certifi-2026.5.20 click-8.4.1 datasets-5.0.0 dill-0.4.1 frozenlist-1.8.0 fsspec-2026.4.0 h11-0.16.0 hf-xet-1.5.1 httpcore-1.0.9 httpx-0.28.1 huggingface-hub-1.19.0 markdown-it-py-4.2.0 mdurl-0.1.2 multidict-6.7.1 multiprocess-0.70.19 propcache-0.5.2 pyarrow-24.0.0 pygments-2.20.0 pyyaml-6.0.3 requests-2.34.2 rich-15.0.0 shellingham-1.5.4 tqdm-4.68.2 typer-0.25.1 xxhash-3.7.0 yarl-1.24.2\n\u001B[43mNote: you may need to restart the kernel using %restart_python or dbutils.library.restartPython() to use updated packages.\u001B[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install datasets\n",
     "dbutils.library.restartPython()"
@@ -106,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -123,16 +114,7 @@
      "title": "Cell 4"
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Catalog mmf already exists — skipping creation\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# CREATE CATALOG IF NOT EXISTS mmf\n",
     "# Workaround: UC validates metastore storage root before the existence check,\n",
@@ -147,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -164,16 +146,7 @@
      "title": "Cell 5"
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Schema mmf.fresh_retail_net: ready\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# CREATE SCHEMA IF NOT EXISTS mmf.fresh_retail_net\n",
     "# (Catalog mmf is expected to already exist — created manually or by cell 4)\n",
@@ -202,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -219,107 +192,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/databricks/python_shell/dbruntime/huggingface_patches/datasets.py:45: UserWarning: The cache_dir for this dataset is /tmp/tmpmgqsjdot, which is not a persistent path.Therefore, if/when the cluster restarts, the downloaded dataset will be lost.The persistent storage options for this workspace/cluster config are: [UC Volumes].Please update either `cache_dir` or the environment variable `HF_DATASETS_CACHE`to be under one of the following root directories: ['/Volumes/']\n  warnings.warn(warning_message)\nWarning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\nWARNING:huggingface_hub.utils._http:Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4b6934f9ee314f9c871222ff2748f745",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "README.md:   0%|          | 0.00/4.87k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/databricks/python_shell/dbruntime/huggingface_patches/datasets.py:14: UserWarning: During large dataset downloads, there could be multiple progress bar widgets that can cause performance issues for your notebook or browser. To avoid these issues, use `datasets.utils.logging.disable_progress_bar()` to turn off the progress bars.\n  warnings.warn(\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "044d6980f471410db96f2d9113c14c77",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "data/train.parquet:   0%|          | 0.00/106M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "453163bad3584b819823d4dbd554e521",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "data/eval.parquet:   0%|          | 0.00/8.44M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2098062e6e894ff5b2ad8e6e6c0b1102",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Generating train split:   0%|          | 0/4500000 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "51323fa29a4443ed8bcf53f60d7d18cb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Generating eval split:   0%|          | 0/350000 [00:00<?, ? examples/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DatasetDict({\n    train: Dataset({\n        features: ['city_id', 'store_id', 'management_group_id', 'first_category_id', 'second_category_id', 'third_category_id', 'product_id', 'dt', 'sale_amount', 'hours_sale', 'stock_hour6_22_cnt', 'hours_stock_status', 'discount', 'holiday_flag', 'activity_flag', 'precpt', 'avg_temperature', 'avg_humidity', 'avg_wind_level'],\n        num_rows: 4500000\n    })\n    eval: Dataset({\n        features: ['city_id', 'store_id', 'management_group_id', 'first_category_id', 'second_category_id', 'third_category_id', 'product_id', 'dt', 'sale_amount', 'hours_sale', 'stock_hour6_22_cnt', 'hours_stock_status', 'discount', 'holiday_flag', 'activity_flag', 'precpt', 'avg_temperature', 'avg_humidity', 'avg_wind_level'],\n        num_rows: 350000\n    })\n})\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import tempfile, os\n",
     "\n",
@@ -358,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -375,16 +248,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Train rows:  4,500,000\nEval rows:   350,000\nTotal rows:  4,850,000\nColumns:     ['city_id', 'store_id', 'management_group_id', 'first_category_id', 'second_category_id', 'third_category_id', 'product_id', 'dt', 'sale_amount', 'hours_sale', 'stock_hour6_22_cnt', 'hours_stock_status', 'discount', 'holiday_flag', 'activity_flag', 'precpt', 'avg_temperature', 'avg_humidity', 'avg_wind_level', 'split']\nDate range:  2024-03-28 — 2024-07-02\nUnique stores:   898\nUnique products: 865\nUnique combos:   50,000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -407,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -424,16 +288,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root\n |-- city_id: long (nullable = true)\n |-- store_id: long (nullable = true)\n |-- management_group_id: long (nullable = true)\n |-- first_category_id: long (nullable = true)\n |-- second_category_id: long (nullable = true)\n |-- third_category_id: long (nullable = true)\n |-- product_id: long (nullable = true)\n |-- dt: date (nullable = true)\n |-- sale_amount: double (nullable = true)\n |-- stock_hour6_22_cnt: integer (nullable = true)\n |-- discount: double (nullable = true)\n |-- holiday_flag: integer (nullable = true)\n |-- activity_flag: integer (nullable = true)\n |-- precpt: double (nullable = true)\n |-- avg_temperature: double (nullable = true)\n |-- avg_humidity: double (nullable = true)\n |-- avg_wind_level: double (nullable = true)\n |-- split: string (nullable = true)\n\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Drop hourly array columns (not needed for daily MMF) and convert date\n",
     "pdf_raw = pdf_raw.drop(columns=[\"hours_sale\", \"hours_stock_status\"])\n",
@@ -445,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -462,16 +317,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saved raw data to mmf.fresh_retail_net.daily_sales_raw\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_raw.write.mode(\"overwrite\").saveAsTable(\"mmf.fresh_retail_net.daily_sales_raw\")\n",
     "print(\"Saved raw data to mmf.fresh_retail_net.daily_sales_raw\")"
@@ -498,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -516,189 +362,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/html": [
-       "<style scoped>\n",
-       "  .table-result-container {\n",
-       "    max-height: 300px;\n",
-       "    overflow: auto;\n",
-       "  }\n",
-       "  table, th, td {\n",
-       "    border: 1px solid black;\n",
-       "    border-collapse: collapse;\n",
-       "  }\n",
-       "  th, td {\n",
-       "    padding: 5px;\n",
-       "  }\n",
-       "  th {\n",
-       "    text-align: left;\n",
-       "  }\n",
-       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>total_rows</th><th>unique_stores</th><th>unique_products</th><th>unique_cities</th><th>min_date</th><th>max_date</th><th>total_days</th><th>avg_daily_sales</th><th>avg_discount</th></tr></thead><tbody><tr><td>4850000</td><td>898</td><td>865</td><td>18</td><td>2024-03-28</td><td>2024-07-02</td><td>97</td><td>1.0126</td><td>0.9119</td></tr></tbody></table></div>"
-      ]
-     },
-     "metadata": {
-      "application/vnd.databricks.v1+output": {
-       "addedWidgets": {},
-       "aggData": [],
-       "aggError": "",
-       "aggOverflow": false,
-       "aggSchema": [],
-       "aggSeriesLimitReached": false,
-       "aggType": "",
-       "arguments": {},
-       "columnCustomDisplayInfos": {},
-       "data": [
-        [
-         4850000,
-         898,
-         865,
-         18,
-         "2024-03-28",
-         "2024-07-02",
-         97,
-         1.0126,
-         0.9119
-        ]
-       ],
-       "datasetInfos": [
-        {
-         "name": "_sqldf",
-         "schema": {
-          "fields": [
-           {
-            "metadata": {},
-            "name": "total_rows",
-            "nullable": false,
-            "type": "long"
-           },
-           {
-            "metadata": {},
-            "name": "unique_stores",
-            "nullable": false,
-            "type": "long"
-           },
-           {
-            "metadata": {},
-            "name": "unique_products",
-            "nullable": false,
-            "type": "long"
-           },
-           {
-            "metadata": {},
-            "name": "unique_cities",
-            "nullable": false,
-            "type": "long"
-           },
-           {
-            "metadata": {},
-            "name": "min_date",
-            "nullable": true,
-            "type": "date"
-           },
-           {
-            "metadata": {},
-            "name": "max_date",
-            "nullable": true,
-            "type": "date"
-           },
-           {
-            "metadata": {},
-            "name": "total_days",
-            "nullable": true,
-            "type": "integer"
-           },
-           {
-            "metadata": {},
-            "name": "avg_daily_sales",
-            "nullable": true,
-            "type": "double"
-           },
-           {
-            "metadata": {},
-            "name": "avg_discount",
-            "nullable": true,
-            "type": "double"
-           }
-          ],
-          "type": "struct"
-         },
-         "tableIdentifier": null,
-         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
-        }
-       ],
-       "dbfsResultPath": null,
-       "isJsonSchema": true,
-       "metadata": {
-        "createTempViewForImplicitDf": true,
-        "dataframeName": "_sqldf",
-        "executionCount": 18
-       },
-       "overflow": false,
-       "plotOptions": {
-        "customPlotOptions": {},
-        "displayType": "table",
-        "pivotAggregation": null,
-        "pivotColumns": null,
-        "xColumns": null,
-        "yColumns": null
-       },
-       "removedWidgets": [],
-       "schema": [
-        {
-         "metadata": "{}",
-         "name": "total_rows",
-         "type": "\"long\""
-        },
-        {
-         "metadata": "{}",
-         "name": "unique_stores",
-         "type": "\"long\""
-        },
-        {
-         "metadata": "{}",
-         "name": "unique_products",
-         "type": "\"long\""
-        },
-        {
-         "metadata": "{}",
-         "name": "unique_cities",
-         "type": "\"long\""
-        },
-        {
-         "metadata": "{}",
-         "name": "min_date",
-         "type": "\"date\""
-        },
-        {
-         "metadata": "{}",
-         "name": "max_date",
-         "type": "\"date\""
-        },
-        {
-         "metadata": "{}",
-         "name": "total_days",
-         "type": "\"integer\""
-        },
-        {
-         "metadata": "{}",
-         "name": "avg_daily_sales",
-         "type": "\"double\""
-        },
-        {
-         "metadata": "{}",
-         "name": "avg_discount",
-         "type": "\"double\""
-        }
-       ],
-       "type": "table"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%sql\n",
     "SELECT\n",
@@ -716,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -734,117 +398,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/html": [
-       "<style scoped>\n",
-       "  .table-result-container {\n",
-       "    max-height: 300px;\n",
-       "    overflow: auto;\n",
-       "  }\n",
-       "  table, th, td {\n",
-       "    border: 1px solid black;\n",
-       "    border-collapse: collapse;\n",
-       "  }\n",
-       "  th, td {\n",
-       "    padding: 5px;\n",
-       "  }\n",
-       "  th {\n",
-       "    text-align: left;\n",
-       "  }\n",
-       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>min_days</th><th>avg_days</th><th>max_days</th></tr></thead><tbody><tr><td>97</td><td>97.0</td><td>97</td></tr></tbody></table></div>"
-      ]
-     },
-     "metadata": {
-      "application/vnd.databricks.v1+output": {
-       "addedWidgets": {},
-       "aggData": [],
-       "aggError": "",
-       "aggOverflow": false,
-       "aggSchema": [],
-       "aggSeriesLimitReached": false,
-       "aggType": "",
-       "arguments": {},
-       "columnCustomDisplayInfos": {},
-       "data": [
-        [
-         97,
-         97.0,
-         97
-        ]
-       ],
-       "datasetInfos": [
-        {
-         "name": "_sqldf",
-         "schema": {
-          "fields": [
-           {
-            "metadata": {},
-            "name": "min_days",
-            "nullable": true,
-            "type": "long"
-           },
-           {
-            "metadata": {},
-            "name": "avg_days",
-            "nullable": true,
-            "type": "double"
-           },
-           {
-            "metadata": {},
-            "name": "max_days",
-            "nullable": true,
-            "type": "long"
-           }
-          ],
-          "type": "struct"
-         },
-         "tableIdentifier": null,
-         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
-        }
-       ],
-       "dbfsResultPath": null,
-       "isJsonSchema": true,
-       "metadata": {
-        "createTempViewForImplicitDf": true,
-        "dataframeName": "_sqldf",
-        "executionCount": 19
-       },
-       "overflow": false,
-       "plotOptions": {
-        "customPlotOptions": {},
-        "displayType": "table",
-        "pivotAggregation": null,
-        "pivotColumns": null,
-        "xColumns": null,
-        "yColumns": null
-       },
-       "removedWidgets": [],
-       "schema": [
-        {
-         "metadata": "{}",
-         "name": "min_days",
-         "type": "\"long\""
-        },
-        {
-         "metadata": "{}",
-         "name": "avg_days",
-         "type": "\"double\""
-        },
-        {
-         "metadata": "{}",
-         "name": "max_days",
-         "type": "\"long\""
-        }
-       ],
-       "type": "table"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%sql\n",
     "-- Check density: how many days does each store-product combo have?\n",
@@ -883,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -900,16 +454,7 @@
      "title": "Cell 16"
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Combos in both splits: 50,000\nSampled combos: 1000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pyspark.sql import functions as F\n",
     "\n",
@@ -936,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -953,16 +498,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sampled rows: 97,000\nTrain series: 1000  |  Eval series: 1000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Filter to sampled combos (both train and eval data)\n",
     "df_sampled = (\n",
@@ -1008,7 +544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -1025,16 +561,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Train rows: 90,000  |  Series: 1000\nScore rows: 7,000  |  Series: 1000\n\nTrain date range: 2024-03-28 — 2024-06-25\nScore date range: 2024-06-26 — 2024-07-02\nGap check: train ends 2024-06-25, score starts 2024-06-26 (should be consecutive)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "regressor_cols = [\n",
     "    \"discount\",\n",
@@ -1083,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -1100,16 +627,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saved train data to mmf.fresh_retail_net.demand_train\nSaved score data to mmf.fresh_retail_net.demand_score\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_train.write.mode(\"overwrite\").saveAsTable(\"mmf.fresh_retail_net.demand_train\")\n",
     "df_score.write.mode(\"overwrite\").saveAsTable(\"mmf.fresh_retail_net.demand_score\")\n",
@@ -1138,7 +656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -1156,187 +674,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/html": [
-       "<style scoped>\n",
-       "  .table-result-container {\n",
-       "    max-height: 300px;\n",
-       "    overflow: auto;\n",
-       "  }\n",
-       "  table, th, td {\n",
-       "    border: 1px solid black;\n",
-       "    border-collapse: collapse;\n",
-       "  }\n",
-       "  th, td {\n",
-       "    padding: 5px;\n",
-       "  }\n",
-       "  th {\n",
-       "    text-align: left;\n",
-       "  }\n",
-       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>table_name</th><th>total_rows</th><th>num_series</th><th>min_date</th><th>max_date</th><th>total_days</th><th>avg_daily_demand</th><th>pct_nonzero</th></tr></thead><tbody><tr><td>train</td><td>90000</td><td>1000</td><td>2024-03-28</td><td>2024-06-25</td><td>90</td><td>0.9763</td><td>95.4</td></tr><tr><td>score</td><td>7000</td><td>1000</td><td>2024-06-26</td><td>2024-07-02</td><td>7</td><td>null</td><td>null</td></tr></tbody></table></div>"
-      ]
-     },
-     "metadata": {
-      "application/vnd.databricks.v1+output": {
-       "addedWidgets": {},
-       "aggData": [],
-       "aggError": "",
-       "aggOverflow": false,
-       "aggSchema": [],
-       "aggSeriesLimitReached": false,
-       "aggType": "",
-       "arguments": {},
-       "columnCustomDisplayInfos": {},
-       "data": [
-        [
-         "train",
-         90000,
-         1000,
-         "2024-03-28",
-         "2024-06-25",
-         90,
-         0.9763,
-         95.4
-        ],
-        [
-         "score",
-         7000,
-         1000,
-         "2024-06-26",
-         "2024-07-02",
-         7,
-         null,
-         null
-        ]
-       ],
-       "datasetInfos": [
-        {
-         "name": "_sqldf",
-         "schema": {
-          "fields": [
-           {
-            "metadata": {},
-            "name": "table_name",
-            "nullable": false,
-            "type": "string"
-           },
-           {
-            "metadata": {},
-            "name": "total_rows",
-            "nullable": false,
-            "type": "long"
-           },
-           {
-            "metadata": {},
-            "name": "num_series",
-            "nullable": false,
-            "type": "long"
-           },
-           {
-            "metadata": {},
-            "name": "min_date",
-            "nullable": true,
-            "type": "date"
-           },
-           {
-            "metadata": {},
-            "name": "max_date",
-            "nullable": true,
-            "type": "date"
-           },
-           {
-            "metadata": {},
-            "name": "total_days",
-            "nullable": true,
-            "type": "integer"
-           },
-           {
-            "metadata": {},
-            "name": "avg_daily_demand",
-            "nullable": true,
-            "type": "double"
-           },
-           {
-            "metadata": {},
-            "name": "pct_nonzero",
-            "nullable": true,
-            "type": "double"
-           }
-          ],
-          "type": "struct"
-         },
-         "tableIdentifier": null,
-         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
-        }
-       ],
-       "dbfsResultPath": null,
-       "isJsonSchema": true,
-       "metadata": {
-        "createTempViewForImplicitDf": true,
-        "dataframeName": "_sqldf",
-        "executionCount": 7
-       },
-       "overflow": false,
-       "plotOptions": {
-        "customPlotOptions": {},
-        "displayType": "table",
-        "pivotAggregation": null,
-        "pivotColumns": null,
-        "xColumns": null,
-        "yColumns": null
-       },
-       "removedWidgets": [],
-       "schema": [
-        {
-         "metadata": "{}",
-         "name": "table_name",
-         "type": "\"string\""
-        },
-        {
-         "metadata": "{}",
-         "name": "total_rows",
-         "type": "\"long\""
-        },
-        {
-         "metadata": "{}",
-         "name": "num_series",
-         "type": "\"long\""
-        },
-        {
-         "metadata": "{}",
-         "name": "min_date",
-         "type": "\"date\""
-        },
-        {
-         "metadata": "{}",
-         "name": "max_date",
-         "type": "\"date\""
-        },
-        {
-         "metadata": "{}",
-         "name": "total_days",
-         "type": "\"integer\""
-        },
-        {
-         "metadata": "{}",
-         "name": "avg_daily_demand",
-         "type": "\"double\""
-        },
-        {
-         "metadata": "{}",
-         "name": "pct_nonzero",
-         "type": "\"double\""
-        }
-       ],
-       "type": "table"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%sql\n",
     "SELECT 'train' AS table_name,\n",
@@ -1362,7 +700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -1380,274 +718,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/html": [
-       "<style scoped>\n",
-       "  .table-result-container {\n",
-       "    max-height: 300px;\n",
-       "    overflow: auto;\n",
-       "  }\n",
-       "  table, th, td {\n",
-       "    border: 1px solid black;\n",
-       "    border-collapse: collapse;\n",
-       "  }\n",
-       "  th, td {\n",
-       "    padding: 5px;\n",
-       "  }\n",
-       "  th {\n",
-       "    text-align: left;\n",
-       "  }\n",
-       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>unique_id</th><th>total_days</th><th>total_demand</th><th>avg_daily_demand</th><th>active_days</th></tr></thead><tbody><tr><td>496_267</td><td>90</td><td>1689.3</td><td>18.77</td><td>87</td></tr><tr><td>630_267</td><td>90</td><td>1512.2</td><td>16.8022</td><td>90</td></tr><tr><td>290_267</td><td>90</td><td>1219.0</td><td>13.5444</td><td>87</td></tr><tr><td>831_267</td><td>90</td><td>1127.6</td><td>12.5289</td><td>87</td></tr><tr><td>822_117</td><td>90</td><td>657.6</td><td>7.3067</td><td>87</td></tr><tr><td>637_589</td><td>90</td><td>638.1</td><td>7.09</td><td>90</td></tr><tr><td>154_691</td><td>90</td><td>615.4</td><td>6.8378</td><td>89</td></tr><tr><td>187_117</td><td>90</td><td>563.4</td><td>6.26</td><td>90</td></tr><tr><td>557_70</td><td>90</td><td>511.0</td><td>5.6778</td><td>90</td></tr><tr><td>312_691</td><td>90</td><td>481.5</td><td>5.35</td><td>90</td></tr><tr><td>628_70</td><td>90</td><td>440.5</td><td>4.8944</td><td>89</td></tr><tr><td>91_117</td><td>90</td><td>423.2</td><td>4.7022</td><td>88</td></tr><tr><td>405_691</td><td>90</td><td>407.4</td><td>4.5267</td><td>89</td></tr><tr><td>176_4</td><td>90</td><td>406.6</td><td>4.5178</td><td>90</td></tr><tr><td>569_4</td><td>90</td><td>402.7</td><td>4.4744</td><td>90</td></tr><tr><td>890_70</td><td>90</td><td>401.7</td><td>4.4633</td><td>88</td></tr><tr><td>561_300</td><td>90</td><td>395.65</td><td>4.3961</td><td>89</td></tr><tr><td>296_117</td><td>90</td><td>377.6</td><td>4.1956</td><td>87</td></tr><tr><td>173_70</td><td>90</td><td>364.5</td><td>4.05</td><td>89</td></tr><tr><td>612_4</td><td>90</td><td>364.1</td><td>4.0456</td><td>89</td></tr></tbody></table></div>"
-      ]
-     },
-     "metadata": {
-      "application/vnd.databricks.v1+output": {
-       "addedWidgets": {},
-       "aggData": [],
-       "aggError": "",
-       "aggOverflow": false,
-       "aggSchema": [],
-       "aggSeriesLimitReached": false,
-       "aggType": "",
-       "arguments": {},
-       "columnCustomDisplayInfos": {},
-       "data": [
-        [
-         "496_267",
-         90,
-         1689.3,
-         18.77,
-         87
-        ],
-        [
-         "630_267",
-         90,
-         1512.2,
-         16.8022,
-         90
-        ],
-        [
-         "290_267",
-         90,
-         1219.0,
-         13.5444,
-         87
-        ],
-        [
-         "831_267",
-         90,
-         1127.6,
-         12.5289,
-         87
-        ],
-        [
-         "822_117",
-         90,
-         657.6,
-         7.3067,
-         87
-        ],
-        [
-         "637_589",
-         90,
-         638.1,
-         7.09,
-         90
-        ],
-        [
-         "154_691",
-         90,
-         615.4,
-         6.8378,
-         89
-        ],
-        [
-         "187_117",
-         90,
-         563.4,
-         6.26,
-         90
-        ],
-        [
-         "557_70",
-         90,
-         511.0,
-         5.6778,
-         90
-        ],
-        [
-         "312_691",
-         90,
-         481.5,
-         5.35,
-         90
-        ],
-        [
-         "628_70",
-         90,
-         440.5,
-         4.8944,
-         89
-        ],
-        [
-         "91_117",
-         90,
-         423.2,
-         4.7022,
-         88
-        ],
-        [
-         "405_691",
-         90,
-         407.4,
-         4.5267,
-         89
-        ],
-        [
-         "176_4",
-         90,
-         406.6,
-         4.5178,
-         90
-        ],
-        [
-         "569_4",
-         90,
-         402.7,
-         4.4744,
-         90
-        ],
-        [
-         "890_70",
-         90,
-         401.7,
-         4.4633,
-         88
-        ],
-        [
-         "561_300",
-         90,
-         395.65,
-         4.3961,
-         89
-        ],
-        [
-         "296_117",
-         90,
-         377.6,
-         4.1956,
-         87
-        ],
-        [
-         "173_70",
-         90,
-         364.5,
-         4.05,
-         89
-        ],
-        [
-         "612_4",
-         90,
-         364.1,
-         4.0456,
-         89
-        ]
-       ],
-       "datasetInfos": [
-        {
-         "name": "_sqldf",
-         "schema": {
-          "fields": [
-           {
-            "metadata": {},
-            "name": "unique_id",
-            "nullable": true,
-            "type": "string"
-           },
-           {
-            "metadata": {},
-            "name": "total_days",
-            "nullable": false,
-            "type": "long"
-           },
-           {
-            "metadata": {},
-            "name": "total_demand",
-            "nullable": true,
-            "type": "double"
-           },
-           {
-            "metadata": {},
-            "name": "avg_daily_demand",
-            "nullable": true,
-            "type": "double"
-           },
-           {
-            "metadata": {},
-            "name": "active_days",
-            "nullable": true,
-            "type": "long"
-           }
-          ],
-          "type": "struct"
-         },
-         "tableIdentifier": null,
-         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
-        }
-       ],
-       "dbfsResultPath": null,
-       "isJsonSchema": true,
-       "metadata": {
-        "createTempViewForImplicitDf": true,
-        "dataframeName": "_sqldf",
-        "executionCount": 8
-       },
-       "overflow": false,
-       "plotOptions": {
-        "customPlotOptions": {},
-        "displayType": "table",
-        "pivotAggregation": null,
-        "pivotColumns": null,
-        "xColumns": null,
-        "yColumns": null
-       },
-       "removedWidgets": [],
-       "schema": [
-        {
-         "metadata": "{}",
-         "name": "unique_id",
-         "type": "\"string\""
-        },
-        {
-         "metadata": "{}",
-         "name": "total_days",
-         "type": "\"long\""
-        },
-        {
-         "metadata": "{}",
-         "name": "total_demand",
-         "type": "\"double\""
-        },
-        {
-         "metadata": "{}",
-         "name": "avg_daily_demand",
-         "type": "\"double\""
-        },
-        {
-         "metadata": "{}",
-         "name": "active_days",
-         "type": "\"long\""
-        }
-       ],
-       "type": "table"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%sql\n",
     "-- Top 20 series by total demand (train data)\n",
@@ -1665,7 +736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -1683,865 +754,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/html": [
-       "<style scoped>\n",
-       "  .table-result-container {\n",
-       "    max-height: 300px;\n",
-       "    overflow: auto;\n",
-       "  }\n",
-       "  table, th, td {\n",
-       "    border: 1px solid black;\n",
-       "    border-collapse: collapse;\n",
-       "  }\n",
-       "  th, td {\n",
-       "    padding: 5px;\n",
-       "  }\n",
-       "  th {\n",
-       "    text-align: left;\n",
-       "  }\n",
-       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>ds</th><th>y</th><th>discount</th><th>holiday_flag</th><th>activity_flag</th><th>avg_temperature</th></tr></thead><tbody><tr><td>2024-03-28</td><td>3.8</td><td>0.0</td><td>0</td><td>0</td><td>16.77</td></tr><tr><td>2024-03-29</td><td>2.4</td><td>0.0</td><td>0</td><td>0</td><td>16.52</td></tr><tr><td>2024-03-30</td><td>6.0</td><td>0.0</td><td>1</td><td>0</td><td>16.86</td></tr><tr><td>2024-03-31</td><td>3.3</td><td>0.0</td><td>1</td><td>0</td><td>16.93</td></tr><tr><td>2024-04-01</td><td>3.0</td><td>0.0</td><td>0</td><td>0</td><td>16.51</td></tr><tr><td>2024-04-02</td><td>3.0</td><td>0.0</td><td>0</td><td>0</td><td>17.64</td></tr><tr><td>2024-04-03</td><td>3.0</td><td>0.0</td><td>0</td><td>0</td><td>17.89</td></tr><tr><td>2024-04-04</td><td>4.3</td><td>0.0</td><td>1</td><td>0</td><td>16.64</td></tr><tr><td>2024-04-05</td><td>3.6</td><td>0.0</td><td>1</td><td>0</td><td>16.66</td></tr><tr><td>2024-04-06</td><td>5.3</td><td>0.0</td><td>1</td><td>0</td><td>17.79</td></tr><tr><td>2024-04-07</td><td>3.0</td><td>0.0</td><td>0</td><td>0</td><td>18.03</td></tr><tr><td>2024-04-08</td><td>3.5</td><td>0.0</td><td>0</td><td>0</td><td>17.23</td></tr><tr><td>2024-04-09</td><td>3.6</td><td>0.0</td><td>0</td><td>0</td><td>18.47</td></tr><tr><td>2024-04-10</td><td>3.8</td><td>0.0</td><td>0</td><td>0</td><td>18.14</td></tr><tr><td>2024-04-11</td><td>6.1</td><td>0.0</td><td>0</td><td>0</td><td>18.51</td></tr><tr><td>2024-04-12</td><td>3.4</td><td>0.0</td><td>0</td><td>0</td><td>18.62</td></tr><tr><td>2024-04-13</td><td>4.8</td><td>0.0</td><td>1</td><td>0</td><td>18.98</td></tr><tr><td>2024-04-14</td><td>6.0</td><td>0.0</td><td>1</td><td>0</td><td>18.51</td></tr><tr><td>2024-04-15</td><td>6.0</td><td>0.0</td><td>0</td><td>0</td><td>18.6</td></tr><tr><td>2024-04-16</td><td>6.0</td><td>0.0</td><td>0</td><td>0</td><td>18.61</td></tr><tr><td>2024-04-17</td><td>5.8</td><td>0.0</td><td>0</td><td>0</td><td>18.82</td></tr><tr><td>2024-04-18</td><td>5.4</td><td>0.0</td><td>0</td><td>0</td><td>18.65</td></tr><tr><td>2024-04-19</td><td>6.0</td><td>0.0</td><td>0</td><td>0</td><td>19.08</td></tr><tr><td>2024-04-20</td><td>6.4</td><td>0.0</td><td>1</td><td>0</td><td>19.72</td></tr><tr><td>2024-04-21</td><td>8.8</td><td>0.0</td><td>1</td><td>0</td><td>20.18</td></tr><tr><td>2024-04-22</td><td>6.0</td><td>0.0</td><td>0</td><td>0</td><td>18.98</td></tr><tr><td>2024-04-23</td><td>7.3</td><td>0.0</td><td>0</td><td>0</td><td>18.94</td></tr><tr><td>2024-04-24</td><td>6.5</td><td>0.0</td><td>0</td><td>0</td><td>20.32</td></tr><tr><td>2024-04-25</td><td>9.1</td><td>0.0</td><td>0</td><td>0</td><td>21.01</td></tr><tr><td>2024-04-26</td><td>5.4</td><td>0.0</td><td>0</td><td>0</td><td>20.5</td></tr><tr><td>2024-04-27</td><td>14.1</td><td>0.0</td><td>1</td><td>0</td><td>20.47</td></tr><tr><td>2024-04-28</td><td>18.0</td><td>0.0</td><td>1</td><td>0</td><td>21.23</td></tr><tr><td>2024-04-29</td><td>15.0</td><td>0.0</td><td>0</td><td>0</td><td>20.94</td></tr><tr><td>2024-04-30</td><td>15.0</td><td>0.0</td><td>0</td><td>0</td><td>20.42</td></tr><tr><td>2024-05-01</td><td>15.9</td><td>0.0</td><td>1</td><td>0</td><td>20.01</td></tr><tr><td>2024-05-02</td><td>22.9</td><td>0.0</td><td>1</td><td>0</td><td>20.82</td></tr><tr><td>2024-05-03</td><td>21.8</td><td>0.0</td><td>1</td><td>0</td><td>21.1</td></tr><tr><td>2024-05-04</td><td>0.0</td><td>1.0</td><td>1</td><td>0</td><td>21.98</td></tr><tr><td>2024-05-05</td><td>21.0</td><td>0.0</td><td>1</td><td>0</td><td>20.71</td></tr><tr><td>2024-05-06</td><td>20.8</td><td>0.0</td><td>0</td><td>0</td><td>21.71</td></tr><tr><td>2024-05-07</td><td>20.8</td><td>0.0</td><td>0</td><td>0</td><td>20.66</td></tr><tr><td>2024-05-08</td><td>21.9</td><td>0.0</td><td>0</td><td>0</td><td>21.17</td></tr><tr><td>2024-05-09</td><td>25.3</td><td>0.0</td><td>0</td><td>0</td><td>21.54</td></tr><tr><td>2024-05-10</td><td>27.3</td><td>0.0</td><td>0</td><td>0</td><td>20.48</td></tr><tr><td>2024-05-11</td><td>29.4</td><td>0.0</td><td>1</td><td>0</td><td>21.41</td></tr><tr><td>2024-05-12</td><td>33.8</td><td>0.0</td><td>1</td><td>0</td><td>21.88</td></tr><tr><td>2024-05-13</td><td>25.7</td><td>0.0</td><td>0</td><td>0</td><td>21.59</td></tr><tr><td>2024-05-14</td><td>29.1</td><td>0.0</td><td>0</td><td>0</td><td>22.54</td></tr><tr><td>2024-05-15</td><td>24.4</td><td>0.0</td><td>0</td><td>0</td><td>22.19</td></tr><tr><td>2024-05-16</td><td>23.6</td><td>0.0</td><td>0</td><td>0</td><td>23.0</td></tr><tr><td>2024-05-17</td><td>0.0</td><td>1.0</td><td>0</td><td>0</td><td>23.18</td></tr><tr><td>2024-05-18</td><td>0.4</td><td>1.0</td><td>1</td><td>0</td><td>23.09</td></tr><tr><td>2024-05-19</td><td>31.9</td><td>0.0</td><td>1</td><td>0</td><td>23.53</td></tr><tr><td>2024-05-20</td><td>28.0</td><td>0.0</td><td>0</td><td>0</td><td>22.9</td></tr><tr><td>2024-05-21</td><td>28.9</td><td>0.0</td><td>0</td><td>0</td><td>22.72</td></tr><tr><td>2024-05-22</td><td>26.5</td><td>0.0</td><td>0</td><td>0</td><td>22.32</td></tr><tr><td>2024-05-23</td><td>25.4</td><td>0.0</td><td>0</td><td>0</td><td>23.39</td></tr><tr><td>2024-05-24</td><td>20.8</td><td>0.0</td><td>0</td><td>0</td><td>22.18</td></tr><tr><td>2024-05-25</td><td>31.7</td><td>0.0</td><td>1</td><td>0</td><td>22.99</td></tr><tr><td>2024-05-26</td><td>33.4</td><td>0.0</td><td>1</td><td>0</td><td>22.13</td></tr><tr><td>2024-05-27</td><td>31.4</td><td>0.0</td><td>0</td><td>0</td><td>21.63</td></tr><tr><td>2024-05-28</td><td>26.8</td><td>0.0</td><td>0</td><td>0</td><td>21.37</td></tr><tr><td>2024-05-29</td><td>24.5</td><td>0.0</td><td>0</td><td>0</td><td>21.51</td></tr><tr><td>2024-05-30</td><td>27.1</td><td>0.0</td><td>0</td><td>0</td><td>22.16</td></tr><tr><td>2024-05-31</td><td>28.7</td><td>0.0</td><td>0</td><td>0</td><td>22.2</td></tr><tr><td>2024-06-01</td><td>32.5</td><td>0.0</td><td>1</td><td>0</td><td>22.84</td></tr><tr><td>2024-06-02</td><td>29.2</td><td>0.0</td><td>1</td><td>0</td><td>22.95</td></tr><tr><td>2024-06-03</td><td>29.0</td><td>0.0</td><td>0</td><td>0</td><td>22.92</td></tr><tr><td>2024-06-04</td><td>27.5</td><td>0.0</td><td>0</td><td>0</td><td>23.92</td></tr><tr><td>2024-06-05</td><td>0.0</td><td>1.0</td><td>0</td><td>0</td><td>24.12</td></tr><tr><td>2024-06-06</td><td>27.8</td><td>0.0</td><td>0</td><td>0</td><td>24.27</td></tr><tr><td>2024-06-07</td><td>27.1</td><td>0.0</td><td>0</td><td>0</td><td>24.45</td></tr><tr><td>2024-06-08</td><td>32.9</td><td>0.0</td><td>1</td><td>0</td><td>24.38</td></tr><tr><td>2024-06-09</td><td>30.1</td><td>0.0</td><td>1</td><td>0</td><td>26.42</td></tr><tr><td>2024-06-10</td><td>40.2</td><td>0.0</td><td>1</td><td>0</td><td>25.51</td></tr><tr><td>2024-06-11</td><td>30.3</td><td>0.0</td><td>0</td><td>0</td><td>25.12</td></tr><tr><td>2024-06-12</td><td>29.4</td><td>0.0</td><td>0</td><td>0</td><td>25.33</td></tr><tr><td>2024-06-13</td><td>25.1</td><td>0.0</td><td>0</td><td>0</td><td>25.92</td></tr><tr><td>2024-06-14</td><td>26.0</td><td>0.0</td><td>0</td><td>0</td><td>26.54</td></tr><tr><td>2024-06-15</td><td>35.7</td><td>0.0</td><td>1</td><td>0</td><td>26.32</td></tr><tr><td>2024-06-16</td><td>35.0</td><td>0.0</td><td>1</td><td>0</td><td>27.54</td></tr><tr><td>2024-06-17</td><td>28.3</td><td>0.0</td><td>0</td><td>0</td><td>27.37</td></tr><tr><td>2024-06-18</td><td>28.9</td><td>0.0</td><td>0</td><td>0</td><td>27.58</td></tr><tr><td>2024-06-19</td><td>28.1</td><td>0.0</td><td>0</td><td>0</td><td>27.45</td></tr><tr><td>2024-06-20</td><td>31.5</td><td>0.0</td><td>0</td><td>0</td><td>28.35</td></tr><tr><td>2024-06-21</td><td>28.9</td><td>0.0</td><td>0</td><td>0</td><td>27.78</td></tr><tr><td>2024-06-22</td><td>41.2</td><td>0.0</td><td>1</td><td>0</td><td>28.43</td></tr><tr><td>2024-06-23</td><td>34.5</td><td>0.0</td><td>1</td><td>0</td><td>28.06</td></tr><tr><td>2024-06-24</td><td>33.6</td><td>0.0</td><td>0</td><td>0</td><td>27.41</td></tr><tr><td>2024-06-25</td><td>34.6</td><td>0.0</td><td>0</td><td>0</td><td>28.55</td></tr></tbody></table></div>"
-      ]
-     },
-     "metadata": {
-      "application/vnd.databricks.v1+output": {
-       "addedWidgets": {},
-       "aggData": [],
-       "aggError": "",
-       "aggOverflow": false,
-       "aggSchema": [],
-       "aggSeriesLimitReached": false,
-       "aggType": "",
-       "arguments": {},
-       "columnCustomDisplayInfos": {},
-       "data": [
-        [
-         "2024-03-28",
-         3.8,
-         0.0,
-         0,
-         0,
-         16.77
-        ],
-        [
-         "2024-03-29",
-         2.4,
-         0.0,
-         0,
-         0,
-         16.52
-        ],
-        [
-         "2024-03-30",
-         6.0,
-         0.0,
-         1,
-         0,
-         16.86
-        ],
-        [
-         "2024-03-31",
-         3.3,
-         0.0,
-         1,
-         0,
-         16.93
-        ],
-        [
-         "2024-04-01",
-         3.0,
-         0.0,
-         0,
-         0,
-         16.51
-        ],
-        [
-         "2024-04-02",
-         3.0,
-         0.0,
-         0,
-         0,
-         17.64
-        ],
-        [
-         "2024-04-03",
-         3.0,
-         0.0,
-         0,
-         0,
-         17.89
-        ],
-        [
-         "2024-04-04",
-         4.3,
-         0.0,
-         1,
-         0,
-         16.64
-        ],
-        [
-         "2024-04-05",
-         3.6,
-         0.0,
-         1,
-         0,
-         16.66
-        ],
-        [
-         "2024-04-06",
-         5.3,
-         0.0,
-         1,
-         0,
-         17.79
-        ],
-        [
-         "2024-04-07",
-         3.0,
-         0.0,
-         0,
-         0,
-         18.03
-        ],
-        [
-         "2024-04-08",
-         3.5,
-         0.0,
-         0,
-         0,
-         17.23
-        ],
-        [
-         "2024-04-09",
-         3.6,
-         0.0,
-         0,
-         0,
-         18.47
-        ],
-        [
-         "2024-04-10",
-         3.8,
-         0.0,
-         0,
-         0,
-         18.14
-        ],
-        [
-         "2024-04-11",
-         6.1,
-         0.0,
-         0,
-         0,
-         18.51
-        ],
-        [
-         "2024-04-12",
-         3.4,
-         0.0,
-         0,
-         0,
-         18.62
-        ],
-        [
-         "2024-04-13",
-         4.8,
-         0.0,
-         1,
-         0,
-         18.98
-        ],
-        [
-         "2024-04-14",
-         6.0,
-         0.0,
-         1,
-         0,
-         18.51
-        ],
-        [
-         "2024-04-15",
-         6.0,
-         0.0,
-         0,
-         0,
-         18.6
-        ],
-        [
-         "2024-04-16",
-         6.0,
-         0.0,
-         0,
-         0,
-         18.61
-        ],
-        [
-         "2024-04-17",
-         5.8,
-         0.0,
-         0,
-         0,
-         18.82
-        ],
-        [
-         "2024-04-18",
-         5.4,
-         0.0,
-         0,
-         0,
-         18.65
-        ],
-        [
-         "2024-04-19",
-         6.0,
-         0.0,
-         0,
-         0,
-         19.08
-        ],
-        [
-         "2024-04-20",
-         6.4,
-         0.0,
-         1,
-         0,
-         19.72
-        ],
-        [
-         "2024-04-21",
-         8.8,
-         0.0,
-         1,
-         0,
-         20.18
-        ],
-        [
-         "2024-04-22",
-         6.0,
-         0.0,
-         0,
-         0,
-         18.98
-        ],
-        [
-         "2024-04-23",
-         7.3,
-         0.0,
-         0,
-         0,
-         18.94
-        ],
-        [
-         "2024-04-24",
-         6.5,
-         0.0,
-         0,
-         0,
-         20.32
-        ],
-        [
-         "2024-04-25",
-         9.1,
-         0.0,
-         0,
-         0,
-         21.01
-        ],
-        [
-         "2024-04-26",
-         5.4,
-         0.0,
-         0,
-         0,
-         20.5
-        ],
-        [
-         "2024-04-27",
-         14.1,
-         0.0,
-         1,
-         0,
-         20.47
-        ],
-        [
-         "2024-04-28",
-         18.0,
-         0.0,
-         1,
-         0,
-         21.23
-        ],
-        [
-         "2024-04-29",
-         15.0,
-         0.0,
-         0,
-         0,
-         20.94
-        ],
-        [
-         "2024-04-30",
-         15.0,
-         0.0,
-         0,
-         0,
-         20.42
-        ],
-        [
-         "2024-05-01",
-         15.9,
-         0.0,
-         1,
-         0,
-         20.01
-        ],
-        [
-         "2024-05-02",
-         22.9,
-         0.0,
-         1,
-         0,
-         20.82
-        ],
-        [
-         "2024-05-03",
-         21.8,
-         0.0,
-         1,
-         0,
-         21.1
-        ],
-        [
-         "2024-05-04",
-         0.0,
-         1.0,
-         1,
-         0,
-         21.98
-        ],
-        [
-         "2024-05-05",
-         21.0,
-         0.0,
-         1,
-         0,
-         20.71
-        ],
-        [
-         "2024-05-06",
-         20.8,
-         0.0,
-         0,
-         0,
-         21.71
-        ],
-        [
-         "2024-05-07",
-         20.8,
-         0.0,
-         0,
-         0,
-         20.66
-        ],
-        [
-         "2024-05-08",
-         21.9,
-         0.0,
-         0,
-         0,
-         21.17
-        ],
-        [
-         "2024-05-09",
-         25.3,
-         0.0,
-         0,
-         0,
-         21.54
-        ],
-        [
-         "2024-05-10",
-         27.3,
-         0.0,
-         0,
-         0,
-         20.48
-        ],
-        [
-         "2024-05-11",
-         29.4,
-         0.0,
-         1,
-         0,
-         21.41
-        ],
-        [
-         "2024-05-12",
-         33.8,
-         0.0,
-         1,
-         0,
-         21.88
-        ],
-        [
-         "2024-05-13",
-         25.7,
-         0.0,
-         0,
-         0,
-         21.59
-        ],
-        [
-         "2024-05-14",
-         29.1,
-         0.0,
-         0,
-         0,
-         22.54
-        ],
-        [
-         "2024-05-15",
-         24.4,
-         0.0,
-         0,
-         0,
-         22.19
-        ],
-        [
-         "2024-05-16",
-         23.6,
-         0.0,
-         0,
-         0,
-         23.0
-        ],
-        [
-         "2024-05-17",
-         0.0,
-         1.0,
-         0,
-         0,
-         23.18
-        ],
-        [
-         "2024-05-18",
-         0.4,
-         1.0,
-         1,
-         0,
-         23.09
-        ],
-        [
-         "2024-05-19",
-         31.9,
-         0.0,
-         1,
-         0,
-         23.53
-        ],
-        [
-         "2024-05-20",
-         28.0,
-         0.0,
-         0,
-         0,
-         22.9
-        ],
-        [
-         "2024-05-21",
-         28.9,
-         0.0,
-         0,
-         0,
-         22.72
-        ],
-        [
-         "2024-05-22",
-         26.5,
-         0.0,
-         0,
-         0,
-         22.32
-        ],
-        [
-         "2024-05-23",
-         25.4,
-         0.0,
-         0,
-         0,
-         23.39
-        ],
-        [
-         "2024-05-24",
-         20.8,
-         0.0,
-         0,
-         0,
-         22.18
-        ],
-        [
-         "2024-05-25",
-         31.7,
-         0.0,
-         1,
-         0,
-         22.99
-        ],
-        [
-         "2024-05-26",
-         33.4,
-         0.0,
-         1,
-         0,
-         22.13
-        ],
-        [
-         "2024-05-27",
-         31.4,
-         0.0,
-         0,
-         0,
-         21.63
-        ],
-        [
-         "2024-05-28",
-         26.8,
-         0.0,
-         0,
-         0,
-         21.37
-        ],
-        [
-         "2024-05-29",
-         24.5,
-         0.0,
-         0,
-         0,
-         21.51
-        ],
-        [
-         "2024-05-30",
-         27.1,
-         0.0,
-         0,
-         0,
-         22.16
-        ],
-        [
-         "2024-05-31",
-         28.7,
-         0.0,
-         0,
-         0,
-         22.2
-        ],
-        [
-         "2024-06-01",
-         32.5,
-         0.0,
-         1,
-         0,
-         22.84
-        ],
-        [
-         "2024-06-02",
-         29.2,
-         0.0,
-         1,
-         0,
-         22.95
-        ],
-        [
-         "2024-06-03",
-         29.0,
-         0.0,
-         0,
-         0,
-         22.92
-        ],
-        [
-         "2024-06-04",
-         27.5,
-         0.0,
-         0,
-         0,
-         23.92
-        ],
-        [
-         "2024-06-05",
-         0.0,
-         1.0,
-         0,
-         0,
-         24.12
-        ],
-        [
-         "2024-06-06",
-         27.8,
-         0.0,
-         0,
-         0,
-         24.27
-        ],
-        [
-         "2024-06-07",
-         27.1,
-         0.0,
-         0,
-         0,
-         24.45
-        ],
-        [
-         "2024-06-08",
-         32.9,
-         0.0,
-         1,
-         0,
-         24.38
-        ],
-        [
-         "2024-06-09",
-         30.1,
-         0.0,
-         1,
-         0,
-         26.42
-        ],
-        [
-         "2024-06-10",
-         40.2,
-         0.0,
-         1,
-         0,
-         25.51
-        ],
-        [
-         "2024-06-11",
-         30.3,
-         0.0,
-         0,
-         0,
-         25.12
-        ],
-        [
-         "2024-06-12",
-         29.4,
-         0.0,
-         0,
-         0,
-         25.33
-        ],
-        [
-         "2024-06-13",
-         25.1,
-         0.0,
-         0,
-         0,
-         25.92
-        ],
-        [
-         "2024-06-14",
-         26.0,
-         0.0,
-         0,
-         0,
-         26.54
-        ],
-        [
-         "2024-06-15",
-         35.7,
-         0.0,
-         1,
-         0,
-         26.32
-        ],
-        [
-         "2024-06-16",
-         35.0,
-         0.0,
-         1,
-         0,
-         27.54
-        ],
-        [
-         "2024-06-17",
-         28.3,
-         0.0,
-         0,
-         0,
-         27.37
-        ],
-        [
-         "2024-06-18",
-         28.9,
-         0.0,
-         0,
-         0,
-         27.58
-        ],
-        [
-         "2024-06-19",
-         28.1,
-         0.0,
-         0,
-         0,
-         27.45
-        ],
-        [
-         "2024-06-20",
-         31.5,
-         0.0,
-         0,
-         0,
-         28.35
-        ],
-        [
-         "2024-06-21",
-         28.9,
-         0.0,
-         0,
-         0,
-         27.78
-        ],
-        [
-         "2024-06-22",
-         41.2,
-         0.0,
-         1,
-         0,
-         28.43
-        ],
-        [
-         "2024-06-23",
-         34.5,
-         0.0,
-         1,
-         0,
-         28.06
-        ],
-        [
-         "2024-06-24",
-         33.6,
-         0.0,
-         0,
-         0,
-         27.41
-        ],
-        [
-         "2024-06-25",
-         34.6,
-         0.0,
-         0,
-         0,
-         28.55
-        ]
-       ],
-       "datasetInfos": [
-        {
-         "name": "_sqldf",
-         "schema": {
-          "fields": [
-           {
-            "metadata": {},
-            "name": "ds",
-            "nullable": true,
-            "type": "date"
-           },
-           {
-            "metadata": {},
-            "name": "y",
-            "nullable": true,
-            "type": "double"
-           },
-           {
-            "metadata": {},
-            "name": "discount",
-            "nullable": true,
-            "type": "double"
-           },
-           {
-            "metadata": {},
-            "name": "holiday_flag",
-            "nullable": true,
-            "type": "integer"
-           },
-           {
-            "metadata": {},
-            "name": "activity_flag",
-            "nullable": true,
-            "type": "integer"
-           },
-           {
-            "metadata": {},
-            "name": "avg_temperature",
-            "nullable": true,
-            "type": "double"
-           }
-          ],
-          "type": "struct"
-         },
-         "tableIdentifier": null,
-         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
-        }
-       ],
-       "dbfsResultPath": null,
-       "isJsonSchema": true,
-       "metadata": {
-        "createTempViewForImplicitDf": true,
-        "dataframeName": "_sqldf",
-        "executionCount": 9
-       },
-       "overflow": false,
-       "plotOptions": {
-        "customPlotOptions": {},
-        "displayType": "table",
-        "pivotAggregation": null,
-        "pivotColumns": null,
-        "xColumns": null,
-        "yColumns": null
-       },
-       "removedWidgets": [],
-       "schema": [
-        {
-         "metadata": "{}",
-         "name": "ds",
-         "type": "\"date\""
-        },
-        {
-         "metadata": "{}",
-         "name": "y",
-         "type": "\"double\""
-        },
-        {
-         "metadata": "{}",
-         "name": "discount",
-         "type": "\"double\""
-        },
-        {
-         "metadata": "{}",
-         "name": "holiday_flag",
-         "type": "\"integer\""
-        },
-        {
-         "metadata": "{}",
-         "name": "activity_flag",
-         "type": "\"integer\""
-        },
-        {
-         "metadata": "{}",
-         "name": "avg_temperature",
-         "type": "\"double\""
-        }
-       ],
-       "type": "table"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%sql\n",
     "-- Sample time series for the top-demand series (train only)\n",

--- a/examples/fresh_retail_net/01_fresh_retail_net_data_prep.ipynb
+++ b/examples/fresh_retail_net/01_fresh_retail_net_data_prep.ipynb
@@ -1,0 +1,2654 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "5fb71d61-1ebe-4ed0-9fe3-98ebf1628809",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# FreshRetailNet-50K — Data Ingestion & Preprocessing for MMF\n",
+    "\n",
+    "## Dataset Overview\n",
+    "\n",
+    "**FreshRetailNet-50K** is an open benchmark dataset for perishable grocery demand forecasting,\n",
+    "released by [Dingdong Inc.](https://huggingface.co/datasets/Dingdong-Inc/FreshRetailNet-50K)\n",
+    "It contains **50,000 store-product time series** of daily sales data from **898 stores** across\n",
+    "**18 major cities**, covering **865 perishable SKUs** over a 90-day period (Mar–Jun 2024).\n",
+    "\n",
+    "| Property | Value |\n",
+    "|---|---|\n",
+    "| **Source** | [HuggingFace — Dingdong-Inc/FreshRetailNet-50K](https://huggingface.co/datasets/Dingdong-Inc/FreshRetailNet-50K) |\n",
+    "| **License** | **Creative Commons Attribution 4.0 International (CC BY 4.0)** |\n",
+    "| **Rows** | ~4.85M (4.5M train + 350K eval) |\n",
+    "| **Time Series** | 50,000 store-product combinations |\n",
+    "| **Date Range** | 90 consecutive days (Mar 28 – Jun 25, 2024) |\n",
+    "| **Stores** | 898 across 18 cities |\n",
+    "| **Products** | 865 perishable SKUs |\n",
+    "| **External Regressors** | Discount, holiday, promotions, precipitation, temperature, humidity, wind |\n",
+    "\n",
+    "### License & Attribution\n",
+    "\n",
+    "This dataset is licensed under **CC BY 4.0**, which permits sharing, adaptation, and commercial use — including publication in blog posts — provided that appropriate credit is given.\n",
+    "\n",
+    "> **Citation:** Dingdong Inc. (2025). FreshRetailNet-50K: A Stockout-Annotated Censored Demand Dataset for Latent Demand Recovery and Forecasting in Fresh Retail. https://huggingface.co/datasets/Dingdong-Inc/FreshRetailNet-50K\n",
+    "\n",
+    "### Why This Dataset for MMF?\n",
+    "\n",
+    "- **Dense time series:** Every store-product combo has 90 consecutive daily data points — no sparsity\n",
+    "- **Supply chain relevance:** Perishable grocery demand forecasting is a classic supply chain problem\n",
+    "- **Built-in external regressors:** Discount, holiday, promotions, and weather features ready for MMF\n",
+    "- **Hierarchical structure:** City → Store → Product category hierarchy for grouped forecasting\n",
+    "- **Scale:** 50,000 series (sampled to 1,000 for this demo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "f4a24491-3804-4daa-ac43-6f5a5ff5aaf1",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 1. Setup — Install Dependencies & Create Schema"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781201066312,
+     "inputWidgets": {},
+     "nuid": "6f23a1b4-5e56-4610-9ea0-5cbefd804b7a",
+     "showTitle": false,
+     "startTime": 1781201022399,
+     "submitTime": 1781201021502,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting datasets\n  Downloading datasets-5.0.0-py3-none-any.whl (555 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 555.1/555.1 kB 7.6 MB/s eta 0:00:00\nRequirement already satisfied: pandas in /databricks/python3/lib/python3.10/site-packages (from datasets) (1.5.3)\nCollecting huggingface-hub<2.0,>=0.25.0\n  Downloading huggingface_hub-1.19.0-py3-none-any.whl (693 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 693.4/693.4 kB 13.3 MB/s eta 0:00:00\nCollecting fsspec[http]<=2026.4.0,>=2023.1.0\n  Downloading fsspec-2026.4.0-py3-none-any.whl (203 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 203.4/203.4 kB 12.6 MB/s eta 0:00:00\nRequirement already satisfied: numpy>=1.17 in /databricks/python3/lib/python3.10/site-packages (from datasets) (1.23.5)\nCollecting requests>=2.32.2\n  Downloading requests-2.34.2-py3-none-any.whl (73 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 73.1/73.1 kB 11.3 MB/s eta 0:00:00\nCollecting xxhash\n  Downloading xxhash-3.7.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (193 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 193.3/193.3 kB 12.0 MB/s eta 0:00:00\nRequirement already satisfied: filelock in /databricks/python3/lib/python3.10/site-packages (from datasets) (3.16.1)\nCollecting httpx<1.0.0\n  Downloading httpx-0.28.1-py3-none-any.whl (73 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 73.5/73.5 kB 10.6 MB/s eta 0:00:00\nRequirement already satisfied: packaging in /databricks/python3/lib/python3.10/site-packages (from datasets) (23.2)\nCollecting pyarrow>=21.0.0\n  Downloading pyarrow-24.0.0-cp310-cp310-manylinux_2_28_x86_64.whl (48.8 MB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB 47.5 MB/s eta 0:00:00\nCollecting tqdm>=4.66.3\n  Downloading tqdm-4.68.2-py3-none-any.whl (78 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 78.6/78.6 kB 8.6 MB/s eta 0:00:00\nCollecting dill<0.4.2,>=0.3.0\n  Downloading dill-0.4.1-py3-none-any.whl (120 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 120.0/120.0 kB 15.1 MB/s eta 0:00:00\nCollecting multiprocess<0.70.20\n  Downloading multiprocess-0.70.19-py310-none-any.whl (134 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 134.9/134.9 kB 19.6 MB/s eta 0:00:00\nCollecting pyyaml>=5.1\n  Downloading pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (770 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 770.3/770.3 kB 74.4 MB/s eta 0:00:00\nCollecting aiohttp!=4.0.0a0,!=4.0.0a1\n  Downloading aiohttp-3.14.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (1.7 MB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.7/1.7 MB 81.6 MB/s eta 0:00:00\nCollecting httpcore==1.*\n  Downloading httpcore-1.0.9-py3-none-any.whl (78 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 78.8/78.8 kB 11.5 MB/s eta 0:00:00\nRequirement already satisfied: idna in /databricks/python3/lib/python3.10/site-packages (from httpx<1.0.0->datasets) (3.4)\nRequirement already satisfied: anyio in /databricks/python3/lib/python3.10/site-packages (from httpx<1.0.0->datasets) (3.5.0)\nRequirement already satisfied: certifi in /databricks/python3/lib/python3.10/site-packages (from httpx<1.0.0->datasets) (2022.12.7)\nCollecting h11>=0.16\n  Downloading h11-0.16.0-py3-none-any.whl (37 kB)\nCollecting typer<0.26.0,>=0.20.0\n  Downloading typer-0.25.1-py3-none-any.whl (58 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 58.4/58.4 kB 9.8 MB/s eta 0:00:00\nRequirement already satisfied: typing-extensions>=4.1.0 in /databricks/python3/lib/python3.10/site-packages (from huggingface-hub<2.0,>=0.25.0->datasets) (4.4.0)\nCollecting hf-xet<2.0.0,>=1.5.1\n  Downloading hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (4.5 MB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.5/4.5 MB 114.9 MB/s eta 0:00:00\nCollecting click>=8.4.0\n  Downloading click-8.4.1-py3-none-any.whl (116 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 116.6/116.6 kB 20.5 MB/s eta 0:00:00\nCollecting certifi\n  Downloading certifi-2026.5.20-py3-none-any.whl (134 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 134.1/134.1 kB 23.1 MB/s eta 0:00:00\nRequirement already satisfied: urllib3<3,>=1.26 in /databricks/python3/lib/python3.10/site-packages (from requests>=2.32.2->datasets) (1.26.14)\nRequirement already satisfied: charset_normalizer<4,>=2 in /databricks/python3/lib/python3.10/site-packages (from requests>=2.32.2->datasets) (2.0.4)\nRequirement already satisfied: python-dateutil>=2.8.1 in /databricks/python3/lib/python3.10/site-packages (from pandas->datasets) (2.8.2)\nRequirement already satisfied: pytz>=2020.1 in /databricks/python3/lib/python3.10/site-packages (from pandas->datasets) (2022.7)\nCollecting aiohappyeyeballs>=2.5.0\n  Downloading aiohappyeyeballs-2.6.2-py3-none-any.whl (15 kB)\nCollecting aiosignal>=1.4.0\n  Downloading aiosignal-1.4.0-py3-none-any.whl (7.5 kB)\nCollecting frozenlist>=1.1.1\n  Downloading frozenlist-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl (219 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 219.5/219.5 kB 25.2 MB/s eta 0:00:00\nCollecting multidict<7.0,>=4.5\n  Downloading multidict-6.7.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (243 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 243.3/243.3 kB 26.1 MB/s eta 0:00:00\nCollecting propcache>=0.2.0\n  Downloading propcache-0.5.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (60 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.1/60.1 kB 9.0 MB/s eta 0:00:00\nCollecting yarl<2.0,>=1.17.0\n  Downloading yarl-1.24.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (106 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 106.7/106.7 kB 18.0 MB/s eta 0:00:00\nRequirement already satisfied: attrs>=17.3.0 in /databricks/python3/lib/python3.10/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.4.0,>=2023.1.0->datasets) (22.1.0)\nCollecting async-timeout<6.0,>=4.0\n  Downloading async_timeout-5.0.1-py3-none-any.whl (6.2 kB)\nRequirement already satisfied: six>=1.5 in /usr/lib/python3/dist-packages (from python-dateutil>=2.8.1->pandas->datasets) (1.16.0)\nCollecting rich>=13.8.0\n  Downloading rich-15.0.0-py3-none-any.whl (310 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 310.7/310.7 kB 38.4 MB/s eta 0:00:00\nCollecting shellingham>=1.3.0\n  Downloading shellingham-1.5.4-py2.py3-none-any.whl (9.8 kB)\nCollecting annotated-doc>=0.0.2\n  Downloading annotated_doc-0.0.4-py3-none-any.whl (5.3 kB)\nRequirement already satisfied: sniffio>=1.1 in /databricks/python3/lib/python3.10/site-packages (from anyio->httpx<1.0.0->datasets) (1.2.0)\nCollecting pygments<3.0.0,>=2.13.0\n  Downloading pygments-2.20.0-py3-none-any.whl (1.2 MB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 80.2 MB/s eta 0:00:00\nCollecting markdown-it-py>=2.2.0\n  Downloading markdown_it_py-4.2.0-py3-none-any.whl (91 kB)\n     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 91.7/91.7 kB 16.5 MB/s eta 0:00:00\nCollecting mdurl~=0.1\n  Downloading mdurl-0.1.2-py3-none-any.whl (10.0 kB)\nInstalling collected packages: xxhash, tqdm, shellingham, pyyaml, pygments, pyarrow, propcache, multidict, mdurl, hf-xet, h11, fsspec, frozenlist, dill, click, certifi, async-timeout, annotated-doc, aiohappyeyeballs, yarl, requests, multiprocess, markdown-it-py, httpcore, aiosignal, rich, httpx, aiohttp, typer, huggingface-hub, datasets\n  Attempting uninstall: pygments\n    Found existing installation: Pygments 2.11.2\n    Not uninstalling pygments at /databricks/python3/lib/python3.10/site-packages, outside environment /local_disk0/.ephemeral_nfs/envs/pythonEnv-50c76149-60f9-4139-96ee-9021617427f0\n    Can't uninstall 'Pygments'. No files were found to uninstall.\n  Attempting uninstall: pyarrow\n    Found existing installation: pyarrow 8.0.0\n    Not uninstalling pyarrow at /databricks/python3/lib/python3.10/site-packages, outside environment /local_disk0/.ephemeral_nfs/envs/pythonEnv-50c76149-60f9-4139-96ee-9021617427f0\n    Can't uninstall 'pyarrow'. No files were found to uninstall.\n  Attempting uninstall: click\n    Found existing installation: click 8.0.4\n    Not uninstalling click at /databricks/python3/lib/python3.10/site-packages, outside environment /local_disk0/.ephemeral_nfs/envs/pythonEnv-50c76149-60f9-4139-96ee-9021617427f0\n    Can't uninstall 'click'. No files were found to uninstall.\n  Attempting uninstall: certifi\n    Found existing installation: certifi 2022.12.7\n    Not uninstalling certifi at /databricks/python3/lib/python3.10/site-packages, outside environment /local_disk0/.ephemeral_nfs/envs/pythonEnv-50c76149-60f9-4139-96ee-9021617427f0\n    Can't uninstall 'certifi'. No files were found to uninstall.\n  Attempting uninstall: requests\n    Found existing installation: requests 2.28.1\n    Not uninstalling requests at /databricks/python3/lib/python3.10/site-packages, outside environment /local_disk0/.ephemeral_nfs/envs/pythonEnv-50c76149-60f9-4139-96ee-9021617427f0\n    Can't uninstall 'requests'. No files were found to uninstall.\nSuccessfully installed aiohappyeyeballs-2.6.2 aiohttp-3.14.1 aiosignal-1.4.0 annotated-doc-0.0.4 async-timeout-5.0.1 certifi-2026.5.20 click-8.4.1 datasets-5.0.0 dill-0.4.1 frozenlist-1.8.0 fsspec-2026.4.0 h11-0.16.0 hf-xet-1.5.1 httpcore-1.0.9 httpx-0.28.1 huggingface-hub-1.19.0 markdown-it-py-4.2.0 mdurl-0.1.2 multidict-6.7.1 multiprocess-0.70.19 propcache-0.5.2 pyarrow-24.0.0 pygments-2.20.0 pyyaml-6.0.3 requests-2.34.2 rich-15.0.0 shellingham-1.5.4 tqdm-4.68.2 typer-0.25.1 xxhash-3.7.0 yarl-1.24.2\n\u001B[43mNote: you may need to restart the kernel using %restart_python or dbutils.library.restartPython() to use updated packages.\u001B[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install datasets\n",
+    "dbutils.library.restartPython()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781201526306,
+     "inputWidgets": {},
+     "nuid": "3e957b6c-b68a-470b-a9f0-3899c62449a6",
+     "showTitle": true,
+     "startTime": 1781201525486,
+     "submitTime": 1781201525455,
+     "tableResultSettingsMap": {},
+     "title": "Cell 4"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Catalog mmf already exists — skipping creation\n"
+     ]
+    }
+   ],
+   "source": [
+    "# CREATE CATALOG IF NOT EXISTS mmf\n",
+    "# Workaround: UC validates metastore storage root before the existence check,\n",
+    "# so we guard with an explicit check to avoid the error when the catalog already exists.\n",
+    "existing_catalogs = {r.catalog for r in spark.sql(\"SHOW CATALOGS\").collect()}\n",
+    "if \"mmf\" not in existing_catalogs:\n",
+    "    spark.sql(\"CREATE CATALOG mmf\")\n",
+    "    print(\"Created catalog: mmf\")\n",
+    "else:\n",
+    "    print(\"Catalog mmf already exists — skipping creation\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781201577554,
+     "inputWidgets": {},
+     "nuid": "f9d56ff4-f5a1-421c-837d-85679fd6829c",
+     "showTitle": true,
+     "startTime": 1781201576496,
+     "submitTime": 1781201576468,
+     "tableResultSettingsMap": {},
+     "title": "Cell 5"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Schema mmf.fresh_retail_net: ready\n"
+     ]
+    }
+   ],
+   "source": [
+    "# CREATE SCHEMA IF NOT EXISTS mmf.fresh_retail_net\n",
+    "# (Catalog mmf is expected to already exist — created manually or by cell 4)\n",
+    "spark.sql(\"CREATE SCHEMA IF NOT EXISTS mmf.fresh_retail_net\")\n",
+    "print(\"Schema mmf.fresh_retail_net: ready\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "796b622d-898d-4657-b206-017595893ab2",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 2. Download the Dataset from HuggingFace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781201639039,
+     "inputWidgets": {},
+     "nuid": "bdc2ddd6-7a51-47dc-8c2a-1e9d15f8401e",
+     "showTitle": false,
+     "startTime": 1781201622322,
+     "submitTime": 1781201622254,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/databricks/python_shell/dbruntime/huggingface_patches/datasets.py:45: UserWarning: The cache_dir for this dataset is /tmp/tmpmgqsjdot, which is not a persistent path.Therefore, if/when the cluster restarts, the downloaded dataset will be lost.The persistent storage options for this workspace/cluster config are: [UC Volumes].Please update either `cache_dir` or the environment variable `HF_DATASETS_CACHE`to be under one of the following root directories: ['/Volumes/']\n  warnings.warn(warning_message)\nWarning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\nWARNING:huggingface_hub.utils._http:Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4b6934f9ee314f9c871222ff2748f745",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "README.md:   0%|          | 0.00/4.87k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/databricks/python_shell/dbruntime/huggingface_patches/datasets.py:14: UserWarning: During large dataset downloads, there could be multiple progress bar widgets that can cause performance issues for your notebook or browser. To avoid these issues, use `datasets.utils.logging.disable_progress_bar()` to turn off the progress bars.\n  warnings.warn(\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "044d6980f471410db96f2d9113c14c77",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "data/train.parquet:   0%|          | 0.00/106M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "453163bad3584b819823d4dbd554e521",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "data/eval.parquet:   0%|          | 0.00/8.44M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2098062e6e894ff5b2ad8e6e6c0b1102",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating train split:   0%|          | 0/4500000 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "51323fa29a4443ed8bcf53f60d7d18cb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Generating eval split:   0%|          | 0/350000 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DatasetDict({\n    train: Dataset({\n        features: ['city_id', 'store_id', 'management_group_id', 'first_category_id', 'second_category_id', 'third_category_id', 'product_id', 'dt', 'sale_amount', 'hours_sale', 'stock_hour6_22_cnt', 'hours_stock_status', 'discount', 'holiday_flag', 'activity_flag', 'precpt', 'avg_temperature', 'avg_humidity', 'avg_wind_level'],\n        num_rows: 4500000\n    })\n    eval: Dataset({\n        features: ['city_id', 'store_id', 'management_group_id', 'first_category_id', 'second_category_id', 'third_category_id', 'product_id', 'dt', 'sale_amount', 'hours_sale', 'stock_hour6_22_cnt', 'hours_stock_status', 'discount', 'holiday_flag', 'activity_flag', 'precpt', 'avg_temperature', 'avg_humidity', 'avg_wind_level'],\n        num_rows: 350000\n    })\n})\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tempfile, os\n",
+    "\n",
+    "# HuggingFace datasets needs a writable cache dir (serverless blocks /root/.cache)\n",
+    "hf_cache = tempfile.mkdtemp()\n",
+    "os.environ[\"HF_HOME\"] = hf_cache\n",
+    "os.environ[\"HF_DATASETS_CACHE\"] = hf_cache\n",
+    "\n",
+    "from datasets import load_dataset\n",
+    "\n",
+    "hf_ds = load_dataset(\"Dingdong-Inc/FreshRetailNet-50K\", cache_dir=hf_cache)\n",
+    "print(hf_ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "a3e4fd7b-3007-4495-b6e7-817574793ae8",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 3. Convert to Spark and Save Raw Data\n",
+    "\n",
+    "The dataset has `hours_sale` (list of 24 floats) and `hours_stock_status` (list of 24 ints) columns.\n",
+    "We drop these array columns for the Delta table since MMF operates at daily granularity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781201706217,
+     "inputWidgets": {},
+     "nuid": "b915988d-d3bd-4e7d-abc9-ce9ceeff2c39",
+     "showTitle": false,
+     "startTime": 1781201646135,
+     "submitTime": 1781201646060,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train rows:  4,500,000\nEval rows:   350,000\nTotal rows:  4,850,000\nColumns:     ['city_id', 'store_id', 'management_group_id', 'first_category_id', 'second_category_id', 'third_category_id', 'product_id', 'dt', 'sale_amount', 'hours_sale', 'stock_hour6_22_cnt', 'hours_stock_status', 'discount', 'holiday_flag', 'activity_flag', 'precpt', 'avg_temperature', 'avg_humidity', 'avg_wind_level', 'split']\nDate range:  2024-03-28 — 2024-07-02\nUnique stores:   898\nUnique products: 865\nUnique combos:   50,000\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "# Combine train and eval splits\n",
+    "pdf_train = hf_ds[\"train\"].to_pandas()\n",
+    "pdf_eval = hf_ds[\"eval\"].to_pandas()\n",
+    "pdf_train[\"split\"] = \"train\"\n",
+    "pdf_eval[\"split\"] = \"eval\"\n",
+    "pdf_raw = pd.concat([pdf_train, pdf_eval], ignore_index=True)\n",
+    "\n",
+    "print(f\"Train rows:  {len(pdf_train):,}\")\n",
+    "print(f\"Eval rows:   {len(pdf_eval):,}\")\n",
+    "print(f\"Total rows:  {len(pdf_raw):,}\")\n",
+    "print(f\"Columns:     {list(pdf_raw.columns)}\")\n",
+    "print(f\"Date range:  {pdf_raw['dt'].min()} — {pdf_raw['dt'].max()}\")\n",
+    "print(f\"Unique stores:   {pdf_raw['store_id'].nunique():,}\")\n",
+    "print(f\"Unique products: {pdf_raw['product_id'].nunique():,}\")\n",
+    "print(f\"Unique combos:   {pdf_raw.groupby(['store_id','product_id']).ngroups:,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781201733026,
+     "inputWidgets": {},
+     "nuid": "52523265-5daa-4e0b-9e82-eeac97ab83b7",
+     "showTitle": false,
+     "startTime": 1781201706636,
+     "submitTime": 1781201650239,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root\n |-- city_id: long (nullable = true)\n |-- store_id: long (nullable = true)\n |-- management_group_id: long (nullable = true)\n |-- first_category_id: long (nullable = true)\n |-- second_category_id: long (nullable = true)\n |-- third_category_id: long (nullable = true)\n |-- product_id: long (nullable = true)\n |-- dt: date (nullable = true)\n |-- sale_amount: double (nullable = true)\n |-- stock_hour6_22_cnt: integer (nullable = true)\n |-- discount: double (nullable = true)\n |-- holiday_flag: integer (nullable = true)\n |-- activity_flag: integer (nullable = true)\n |-- precpt: double (nullable = true)\n |-- avg_temperature: double (nullable = true)\n |-- avg_humidity: double (nullable = true)\n |-- avg_wind_level: double (nullable = true)\n |-- split: string (nullable = true)\n\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Drop hourly array columns (not needed for daily MMF) and convert date\n",
+    "pdf_raw = pdf_raw.drop(columns=[\"hours_sale\", \"hours_stock_status\"])\n",
+    "pdf_raw[\"dt\"] = pd.to_datetime(pdf_raw[\"dt\"]).dt.date\n",
+    "\n",
+    "df_raw = spark.createDataFrame(pdf_raw)\n",
+    "df_raw.printSchema()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781201798514,
+     "inputWidgets": {},
+     "nuid": "b3c5e699-8389-43fc-9428-889686e48fd0",
+     "showTitle": false,
+     "startTime": 1781201733117,
+     "submitTime": 1781201652154,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved raw data to mmf.fresh_retail_net.daily_sales_raw\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_raw.write.mode(\"overwrite\").saveAsTable(\"mmf.fresh_retail_net.daily_sales_raw\")\n",
+    "print(\"Saved raw data to mmf.fresh_retail_net.daily_sales_raw\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "52594621-7a4e-40b6-9e1f-65028f94779b",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 4. Explore the Raw Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781201811567,
+     "inputWidgets": {},
+     "nuid": "2a3f1c53-0c9f-41b4-a1b4-bd87656bc89e",
+     "showTitle": false,
+     "startTime": 1781201798551,
+     "submitTime": 1781201655266,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>total_rows</th><th>unique_stores</th><th>unique_products</th><th>unique_cities</th><th>min_date</th><th>max_date</th><th>total_days</th><th>avg_daily_sales</th><th>avg_discount</th></tr></thead><tbody><tr><td>4850000</td><td>898</td><td>865</td><td>18</td><td>2024-03-28</td><td>2024-07-02</td><td>97</td><td>1.0126</td><td>0.9119</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         4850000,
+         898,
+         865,
+         18,
+         "2024-03-28",
+         "2024-07-02",
+         97,
+         1.0126,
+         0.9119
+        ]
+       ],
+       "datasetInfos": [
+        {
+         "name": "_sqldf",
+         "schema": {
+          "fields": [
+           {
+            "metadata": {},
+            "name": "total_rows",
+            "nullable": false,
+            "type": "long"
+           },
+           {
+            "metadata": {},
+            "name": "unique_stores",
+            "nullable": false,
+            "type": "long"
+           },
+           {
+            "metadata": {},
+            "name": "unique_products",
+            "nullable": false,
+            "type": "long"
+           },
+           {
+            "metadata": {},
+            "name": "unique_cities",
+            "nullable": false,
+            "type": "long"
+           },
+           {
+            "metadata": {},
+            "name": "min_date",
+            "nullable": true,
+            "type": "date"
+           },
+           {
+            "metadata": {},
+            "name": "max_date",
+            "nullable": true,
+            "type": "date"
+           },
+           {
+            "metadata": {},
+            "name": "total_days",
+            "nullable": true,
+            "type": "integer"
+           },
+           {
+            "metadata": {},
+            "name": "avg_daily_sales",
+            "nullable": true,
+            "type": "double"
+           },
+           {
+            "metadata": {},
+            "name": "avg_discount",
+            "nullable": true,
+            "type": "double"
+           }
+          ],
+          "type": "struct"
+         },
+         "tableIdentifier": null,
+         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
+        }
+       ],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {
+        "createTempViewForImplicitDf": true,
+        "dataframeName": "_sqldf",
+        "executionCount": 18
+       },
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "total_rows",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "unique_stores",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "unique_products",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "unique_cities",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "min_date",
+         "type": "\"date\""
+        },
+        {
+         "metadata": "{}",
+         "name": "max_date",
+         "type": "\"date\""
+        },
+        {
+         "metadata": "{}",
+         "name": "total_days",
+         "type": "\"integer\""
+        },
+        {
+         "metadata": "{}",
+         "name": "avg_daily_sales",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "avg_discount",
+         "type": "\"double\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%sql\n",
+    "SELECT\n",
+    "  COUNT(*) AS total_rows,\n",
+    "  COUNT(DISTINCT store_id) AS unique_stores,\n",
+    "  COUNT(DISTINCT product_id) AS unique_products,\n",
+    "  COUNT(DISTINCT city_id) AS unique_cities,\n",
+    "  MIN(dt) AS min_date,\n",
+    "  MAX(dt) AS max_date,\n",
+    "  DATEDIFF(MAX(dt), MIN(dt)) + 1 AS total_days,\n",
+    "  ROUND(AVG(sale_amount), 4) AS avg_daily_sales,\n",
+    "  ROUND(AVG(discount), 4) AS avg_discount\n",
+    "FROM mmf.fresh_retail_net.daily_sales_raw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781201814078,
+     "inputWidgets": {},
+     "nuid": "ae53146d-06aa-48f6-885c-c8f8e55f6015",
+     "showTitle": false,
+     "startTime": 1781201811607,
+     "submitTime": 1781201657804,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>min_days</th><th>avg_days</th><th>max_days</th></tr></thead><tbody><tr><td>97</td><td>97.0</td><td>97</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         97,
+         97.0,
+         97
+        ]
+       ],
+       "datasetInfos": [
+        {
+         "name": "_sqldf",
+         "schema": {
+          "fields": [
+           {
+            "metadata": {},
+            "name": "min_days",
+            "nullable": true,
+            "type": "long"
+           },
+           {
+            "metadata": {},
+            "name": "avg_days",
+            "nullable": true,
+            "type": "double"
+           },
+           {
+            "metadata": {},
+            "name": "max_days",
+            "nullable": true,
+            "type": "long"
+           }
+          ],
+          "type": "struct"
+         },
+         "tableIdentifier": null,
+         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
+        }
+       ],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {
+        "createTempViewForImplicitDf": true,
+        "dataframeName": "_sqldf",
+        "executionCount": 19
+       },
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "min_days",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "avg_days",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "max_days",
+         "type": "\"long\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%sql\n",
+    "-- Check density: how many days does each store-product combo have?\n",
+    "SELECT\n",
+    "  MIN(day_count) AS min_days,\n",
+    "  ROUND(AVG(day_count), 1) AS avg_days,\n",
+    "  MAX(day_count) AS max_days\n",
+    "FROM (\n",
+    "  SELECT store_id, product_id, COUNT(*) AS day_count\n",
+    "  FROM mmf.fresh_retail_net.daily_sales_raw\n",
+    "  GROUP BY store_id, product_id\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "27539976-9730-44a7-a88b-6ba6951bbb98",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 5. Sample to 1,000 Store-Product Combos & Prepare for MMF\n",
+    "\n",
+    "We sample 1,000 random store-product combinations from the training split,\n",
+    "then build the MMF-ready table using only data from those combos (both train and eval splits)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207376403,
+     "inputWidgets": {},
+     "nuid": "0bf8fb2b-7b3a-4610-a837-7537c4b352f5",
+     "showTitle": true,
+     "startTime": 1781207371958,
+     "submitTime": 1781207371909,
+     "tableResultSettingsMap": {},
+     "title": "Cell 16"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Combos in both splits: 50,000\nSampled combos: 1000\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "df = spark.table(\"mmf.fresh_retail_net.daily_sales_raw\")\n",
+    "\n",
+    "# Build unique_id on full dataset first\n",
+    "df = df.withColumn(\"unique_id\", F.concat_ws(\"_\", F.col(\"store_id\"), F.col(\"product_id\")))\n",
+    "\n",
+    "# Get combos that exist in BOTH train and eval splits (required for MMF train/score alignment)\n",
+    "train_ids = df.filter(F.col(\"split\") == \"train\").select(\"unique_id\").distinct()\n",
+    "eval_ids = df.filter(F.col(\"split\") == \"eval\").select(\"unique_id\").distinct()\n",
+    "shared_ids = train_ids.intersect(eval_ids)\n",
+    "print(f\"Combos in both splits: {shared_ids.count():,}\")\n",
+    "\n",
+    "# Deterministic sample: hash-based ordering to ensure reproducibility\n",
+    "sampled_ids = (\n",
+    "    shared_ids\n",
+    "    .orderBy(F.hash(\"unique_id\"))\n",
+    "    .limit(1000)\n",
+    ")\n",
+    "sampled_ids.count()  # Materialize the cache\n",
+    "print(f\"Sampled combos: {sampled_ids.count()}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207388418,
+     "inputWidgets": {},
+     "nuid": "9ea1d9ff-76a4-4ad6-81f0-e046b28dcff9",
+     "showTitle": false,
+     "startTime": 1781207382482,
+     "submitTime": 1781207382440,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sampled rows: 97,000\nTrain series: 1000  |  Eval series: 1000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Filter to sampled combos (both train and eval data)\n",
+    "df_sampled = (\n",
+    "    df.join(sampled_ids, on=\"unique_id\", how=\"inner\")\n",
+    "    .withColumnRenamed(\"dt\", \"ds\")\n",
+    "    .withColumnRenamed(\"sale_amount\", \"y\")\n",
+    ")\n",
+    "\n",
+    "# Verify both splits are present for all sampled series\n",
+    "train_count = df_sampled.filter(F.col(\"split\") == \"train\").select(\"unique_id\").distinct().count()\n",
+    "eval_count = df_sampled.filter(F.col(\"split\") == \"eval\").select(\"unique_id\").distinct().count()\n",
+    "print(f\"Sampled rows: {df_sampled.count():,}\")\n",
+    "print(f\"Train series: {train_count}  |  Eval series: {eval_count}\")\n",
+    "assert train_count == eval_count == 1000, f\"Mismatch! train={train_count}, eval={eval_count}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "ff86eba3-a9b0-45d0-acb4-0a93d2c8fac5",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 6. Split into Train & Score Tables for MMF\n",
+    "\n",
+    "MMF expects two separate tables:\n",
+    "- **Train table** — historical data **with** the target column (`y`)\n",
+    "- **Score table** — future dates **without** the target column, but with external regressors\n",
+    "\n",
+    "The FreshRetailNet dataset already provides a natural split:\n",
+    "- `split == \"train\"` → 90 days of history (used for training)\n",
+    "- `split == \"eval\"` → 7 days of future data (used for scoring)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207408455,
+     "inputWidgets": {},
+     "nuid": "cef41ef6-e959-4036-94ef-f56a8c9a4c0e",
+     "showTitle": false,
+     "startTime": 1781207395746,
+     "submitTime": 1781207395713,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train rows: 90,000  |  Series: 1000\nScore rows: 7,000  |  Series: 1000\n\nTrain date range: 2024-03-28 — 2024-06-25\nScore date range: 2024-06-26 — 2024-07-02\nGap check: train ends 2024-06-25, score starts 2024-06-26 (should be consecutive)\n"
+     ]
+    }
+   ],
+   "source": [
+    "regressor_cols = [\n",
+    "    \"discount\",\n",
+    "    \"holiday_flag\",\n",
+    "    \"activity_flag\",\n",
+    "    \"precpt\",\n",
+    "    \"avg_temperature\",\n",
+    "    \"avg_humidity\",\n",
+    "    \"avg_wind_level\",\n",
+    "]\n",
+    "\n",
+    "grouping_cols = [\n",
+    "    \"city_id\",\n",
+    "    \"store_id\",\n",
+    "    \"product_id\",\n",
+    "    \"management_group_id\",\n",
+    "    \"first_category_id\",\n",
+    "    \"second_category_id\",\n",
+    "    \"third_category_id\",\n",
+    "]\n",
+    "\n",
+    "# Train table: historical data WITH the target (y)\n",
+    "df_train = (\n",
+    "    df_sampled\n",
+    "    .filter(F.col(\"split\") == \"train\")\n",
+    "    .select(\"unique_id\", \"ds\", \"y\", *regressor_cols, *grouping_cols, \"stock_hour6_22_cnt\")\n",
+    ")\n",
+    "\n",
+    "# Score table: future dates WITHOUT the target, but with regressors\n",
+    "df_score = (\n",
+    "    df_sampled\n",
+    "    .filter(F.col(\"split\") == \"eval\")\n",
+    "    .select(\"unique_id\", \"ds\", *regressor_cols, *grouping_cols)\n",
+    ")\n",
+    "\n",
+    "print(f\"Train rows: {df_train.count():,}  |  Series: {df_train.select('unique_id').distinct().count()}\")\n",
+    "print(f\"Score rows: {df_score.count():,}  |  Series: {df_score.select('unique_id').distinct().count()}\")\n",
+    "\n",
+    "# Verify date ranges don't overlap\n",
+    "train_max = df_train.agg(F.max(\"ds\")).collect()[0][0]\n",
+    "score_min = df_score.agg(F.min(\"ds\")).collect()[0][0]\n",
+    "print(f\"\\nTrain date range: {df_train.agg(F.min('ds')).collect()[0][0]} — {train_max}\")\n",
+    "print(f\"Score date range: {score_min} — {df_score.agg(F.max('ds')).collect()[0][0]}\")\n",
+    "print(f\"Gap check: train ends {train_max}, score starts {score_min} (should be consecutive)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207421469,
+     "inputWidgets": {},
+     "nuid": "7484a3c6-85f9-4bca-8c0c-ed3e35e7608e",
+     "showTitle": false,
+     "startTime": 1781207408481,
+     "submitTime": 1781207404937,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saved train data to mmf.fresh_retail_net.demand_train\nSaved score data to mmf.fresh_retail_net.demand_score\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_train.write.mode(\"overwrite\").saveAsTable(\"mmf.fresh_retail_net.demand_train\")\n",
+    "df_score.write.mode(\"overwrite\").saveAsTable(\"mmf.fresh_retail_net.demand_score\")\n",
+    "print(\"Saved train data to mmf.fresh_retail_net.demand_train\")\n",
+    "print(\"Saved score data to mmf.fresh_retail_net.demand_score\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "91763d47-90d2-49f1-a39b-3fe6b4e906be",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 7. Validate the Output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207425085,
+     "inputWidgets": {},
+     "nuid": "87a0ba93-02ff-477b-9c60-45c74092ebde",
+     "showTitle": false,
+     "startTime": 1781207421492,
+     "submitTime": 1781207412445,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>table_name</th><th>total_rows</th><th>num_series</th><th>min_date</th><th>max_date</th><th>total_days</th><th>avg_daily_demand</th><th>pct_nonzero</th></tr></thead><tbody><tr><td>train</td><td>90000</td><td>1000</td><td>2024-03-28</td><td>2024-06-25</td><td>90</td><td>0.9763</td><td>95.4</td></tr><tr><td>score</td><td>7000</td><td>1000</td><td>2024-06-26</td><td>2024-07-02</td><td>7</td><td>null</td><td>null</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         "train",
+         90000,
+         1000,
+         "2024-03-28",
+         "2024-06-25",
+         90,
+         0.9763,
+         95.4
+        ],
+        [
+         "score",
+         7000,
+         1000,
+         "2024-06-26",
+         "2024-07-02",
+         7,
+         null,
+         null
+        ]
+       ],
+       "datasetInfos": [
+        {
+         "name": "_sqldf",
+         "schema": {
+          "fields": [
+           {
+            "metadata": {},
+            "name": "table_name",
+            "nullable": false,
+            "type": "string"
+           },
+           {
+            "metadata": {},
+            "name": "total_rows",
+            "nullable": false,
+            "type": "long"
+           },
+           {
+            "metadata": {},
+            "name": "num_series",
+            "nullable": false,
+            "type": "long"
+           },
+           {
+            "metadata": {},
+            "name": "min_date",
+            "nullable": true,
+            "type": "date"
+           },
+           {
+            "metadata": {},
+            "name": "max_date",
+            "nullable": true,
+            "type": "date"
+           },
+           {
+            "metadata": {},
+            "name": "total_days",
+            "nullable": true,
+            "type": "integer"
+           },
+           {
+            "metadata": {},
+            "name": "avg_daily_demand",
+            "nullable": true,
+            "type": "double"
+           },
+           {
+            "metadata": {},
+            "name": "pct_nonzero",
+            "nullable": true,
+            "type": "double"
+           }
+          ],
+          "type": "struct"
+         },
+         "tableIdentifier": null,
+         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
+        }
+       ],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {
+        "createTempViewForImplicitDf": true,
+        "dataframeName": "_sqldf",
+        "executionCount": 7
+       },
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "table_name",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "total_rows",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "num_series",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "min_date",
+         "type": "\"date\""
+        },
+        {
+         "metadata": "{}",
+         "name": "max_date",
+         "type": "\"date\""
+        },
+        {
+         "metadata": "{}",
+         "name": "total_days",
+         "type": "\"integer\""
+        },
+        {
+         "metadata": "{}",
+         "name": "avg_daily_demand",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "pct_nonzero",
+         "type": "\"double\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%sql\n",
+    "SELECT 'train' AS table_name,\n",
+    "  COUNT(*) AS total_rows,\n",
+    "  COUNT(DISTINCT unique_id) AS num_series,\n",
+    "  MIN(ds) AS min_date,\n",
+    "  MAX(ds) AS max_date,\n",
+    "  DATEDIFF(MAX(ds), MIN(ds)) + 1 AS total_days,\n",
+    "  ROUND(AVG(y), 4) AS avg_daily_demand,\n",
+    "  ROUND(SUM(CASE WHEN y > 0 THEN 1 ELSE 0 END) / COUNT(*) * 100, 1) AS pct_nonzero\n",
+    "FROM mmf.fresh_retail_net.demand_train\n",
+    "UNION ALL\n",
+    "SELECT 'score' AS table_name,\n",
+    "  COUNT(*) AS total_rows,\n",
+    "  COUNT(DISTINCT unique_id) AS num_series,\n",
+    "  MIN(ds) AS min_date,\n",
+    "  MAX(ds) AS max_date,\n",
+    "  DATEDIFF(MAX(ds), MIN(ds)) + 1 AS total_days,\n",
+    "  NULL AS avg_daily_demand,\n",
+    "  NULL AS pct_nonzero\n",
+    "FROM mmf.fresh_retail_net.demand_score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207427783,
+     "inputWidgets": {},
+     "nuid": "7756991d-c199-4212-abad-d1ba707234d8",
+     "showTitle": false,
+     "startTime": 1781207425408,
+     "submitTime": 1781207417142,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>unique_id</th><th>total_days</th><th>total_demand</th><th>avg_daily_demand</th><th>active_days</th></tr></thead><tbody><tr><td>496_267</td><td>90</td><td>1689.3</td><td>18.77</td><td>87</td></tr><tr><td>630_267</td><td>90</td><td>1512.2</td><td>16.8022</td><td>90</td></tr><tr><td>290_267</td><td>90</td><td>1219.0</td><td>13.5444</td><td>87</td></tr><tr><td>831_267</td><td>90</td><td>1127.6</td><td>12.5289</td><td>87</td></tr><tr><td>822_117</td><td>90</td><td>657.6</td><td>7.3067</td><td>87</td></tr><tr><td>637_589</td><td>90</td><td>638.1</td><td>7.09</td><td>90</td></tr><tr><td>154_691</td><td>90</td><td>615.4</td><td>6.8378</td><td>89</td></tr><tr><td>187_117</td><td>90</td><td>563.4</td><td>6.26</td><td>90</td></tr><tr><td>557_70</td><td>90</td><td>511.0</td><td>5.6778</td><td>90</td></tr><tr><td>312_691</td><td>90</td><td>481.5</td><td>5.35</td><td>90</td></tr><tr><td>628_70</td><td>90</td><td>440.5</td><td>4.8944</td><td>89</td></tr><tr><td>91_117</td><td>90</td><td>423.2</td><td>4.7022</td><td>88</td></tr><tr><td>405_691</td><td>90</td><td>407.4</td><td>4.5267</td><td>89</td></tr><tr><td>176_4</td><td>90</td><td>406.6</td><td>4.5178</td><td>90</td></tr><tr><td>569_4</td><td>90</td><td>402.7</td><td>4.4744</td><td>90</td></tr><tr><td>890_70</td><td>90</td><td>401.7</td><td>4.4633</td><td>88</td></tr><tr><td>561_300</td><td>90</td><td>395.65</td><td>4.3961</td><td>89</td></tr><tr><td>296_117</td><td>90</td><td>377.6</td><td>4.1956</td><td>87</td></tr><tr><td>173_70</td><td>90</td><td>364.5</td><td>4.05</td><td>89</td></tr><tr><td>612_4</td><td>90</td><td>364.1</td><td>4.0456</td><td>89</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         "496_267",
+         90,
+         1689.3,
+         18.77,
+         87
+        ],
+        [
+         "630_267",
+         90,
+         1512.2,
+         16.8022,
+         90
+        ],
+        [
+         "290_267",
+         90,
+         1219.0,
+         13.5444,
+         87
+        ],
+        [
+         "831_267",
+         90,
+         1127.6,
+         12.5289,
+         87
+        ],
+        [
+         "822_117",
+         90,
+         657.6,
+         7.3067,
+         87
+        ],
+        [
+         "637_589",
+         90,
+         638.1,
+         7.09,
+         90
+        ],
+        [
+         "154_691",
+         90,
+         615.4,
+         6.8378,
+         89
+        ],
+        [
+         "187_117",
+         90,
+         563.4,
+         6.26,
+         90
+        ],
+        [
+         "557_70",
+         90,
+         511.0,
+         5.6778,
+         90
+        ],
+        [
+         "312_691",
+         90,
+         481.5,
+         5.35,
+         90
+        ],
+        [
+         "628_70",
+         90,
+         440.5,
+         4.8944,
+         89
+        ],
+        [
+         "91_117",
+         90,
+         423.2,
+         4.7022,
+         88
+        ],
+        [
+         "405_691",
+         90,
+         407.4,
+         4.5267,
+         89
+        ],
+        [
+         "176_4",
+         90,
+         406.6,
+         4.5178,
+         90
+        ],
+        [
+         "569_4",
+         90,
+         402.7,
+         4.4744,
+         90
+        ],
+        [
+         "890_70",
+         90,
+         401.7,
+         4.4633,
+         88
+        ],
+        [
+         "561_300",
+         90,
+         395.65,
+         4.3961,
+         89
+        ],
+        [
+         "296_117",
+         90,
+         377.6,
+         4.1956,
+         87
+        ],
+        [
+         "173_70",
+         90,
+         364.5,
+         4.05,
+         89
+        ],
+        [
+         "612_4",
+         90,
+         364.1,
+         4.0456,
+         89
+        ]
+       ],
+       "datasetInfos": [
+        {
+         "name": "_sqldf",
+         "schema": {
+          "fields": [
+           {
+            "metadata": {},
+            "name": "unique_id",
+            "nullable": true,
+            "type": "string"
+           },
+           {
+            "metadata": {},
+            "name": "total_days",
+            "nullable": false,
+            "type": "long"
+           },
+           {
+            "metadata": {},
+            "name": "total_demand",
+            "nullable": true,
+            "type": "double"
+           },
+           {
+            "metadata": {},
+            "name": "avg_daily_demand",
+            "nullable": true,
+            "type": "double"
+           },
+           {
+            "metadata": {},
+            "name": "active_days",
+            "nullable": true,
+            "type": "long"
+           }
+          ],
+          "type": "struct"
+         },
+         "tableIdentifier": null,
+         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
+        }
+       ],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {
+        "createTempViewForImplicitDf": true,
+        "dataframeName": "_sqldf",
+        "executionCount": 8
+       },
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "unique_id",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "total_days",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "total_demand",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "avg_daily_demand",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "active_days",
+         "type": "\"long\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%sql\n",
+    "-- Top 20 series by total demand (train data)\n",
+    "SELECT\n",
+    "  unique_id,\n",
+    "  COUNT(*) AS total_days,\n",
+    "  ROUND(SUM(y), 2) AS total_demand,\n",
+    "  ROUND(AVG(y), 4) AS avg_daily_demand,\n",
+    "  SUM(CASE WHEN y > 0 THEN 1 ELSE 0 END) AS active_days\n",
+    "FROM mmf.fresh_retail_net.demand_train\n",
+    "GROUP BY unique_id\n",
+    "ORDER BY total_demand DESC\n",
+    "LIMIT 20"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207430289,
+     "inputWidgets": {},
+     "nuid": "a1c48817-1703-4f63-b3ad-f8d1bdf93949",
+     "showTitle": false,
+     "startTime": 1781207427811,
+     "submitTime": 1781207419059,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>ds</th><th>y</th><th>discount</th><th>holiday_flag</th><th>activity_flag</th><th>avg_temperature</th></tr></thead><tbody><tr><td>2024-03-28</td><td>3.8</td><td>0.0</td><td>0</td><td>0</td><td>16.77</td></tr><tr><td>2024-03-29</td><td>2.4</td><td>0.0</td><td>0</td><td>0</td><td>16.52</td></tr><tr><td>2024-03-30</td><td>6.0</td><td>0.0</td><td>1</td><td>0</td><td>16.86</td></tr><tr><td>2024-03-31</td><td>3.3</td><td>0.0</td><td>1</td><td>0</td><td>16.93</td></tr><tr><td>2024-04-01</td><td>3.0</td><td>0.0</td><td>0</td><td>0</td><td>16.51</td></tr><tr><td>2024-04-02</td><td>3.0</td><td>0.0</td><td>0</td><td>0</td><td>17.64</td></tr><tr><td>2024-04-03</td><td>3.0</td><td>0.0</td><td>0</td><td>0</td><td>17.89</td></tr><tr><td>2024-04-04</td><td>4.3</td><td>0.0</td><td>1</td><td>0</td><td>16.64</td></tr><tr><td>2024-04-05</td><td>3.6</td><td>0.0</td><td>1</td><td>0</td><td>16.66</td></tr><tr><td>2024-04-06</td><td>5.3</td><td>0.0</td><td>1</td><td>0</td><td>17.79</td></tr><tr><td>2024-04-07</td><td>3.0</td><td>0.0</td><td>0</td><td>0</td><td>18.03</td></tr><tr><td>2024-04-08</td><td>3.5</td><td>0.0</td><td>0</td><td>0</td><td>17.23</td></tr><tr><td>2024-04-09</td><td>3.6</td><td>0.0</td><td>0</td><td>0</td><td>18.47</td></tr><tr><td>2024-04-10</td><td>3.8</td><td>0.0</td><td>0</td><td>0</td><td>18.14</td></tr><tr><td>2024-04-11</td><td>6.1</td><td>0.0</td><td>0</td><td>0</td><td>18.51</td></tr><tr><td>2024-04-12</td><td>3.4</td><td>0.0</td><td>0</td><td>0</td><td>18.62</td></tr><tr><td>2024-04-13</td><td>4.8</td><td>0.0</td><td>1</td><td>0</td><td>18.98</td></tr><tr><td>2024-04-14</td><td>6.0</td><td>0.0</td><td>1</td><td>0</td><td>18.51</td></tr><tr><td>2024-04-15</td><td>6.0</td><td>0.0</td><td>0</td><td>0</td><td>18.6</td></tr><tr><td>2024-04-16</td><td>6.0</td><td>0.0</td><td>0</td><td>0</td><td>18.61</td></tr><tr><td>2024-04-17</td><td>5.8</td><td>0.0</td><td>0</td><td>0</td><td>18.82</td></tr><tr><td>2024-04-18</td><td>5.4</td><td>0.0</td><td>0</td><td>0</td><td>18.65</td></tr><tr><td>2024-04-19</td><td>6.0</td><td>0.0</td><td>0</td><td>0</td><td>19.08</td></tr><tr><td>2024-04-20</td><td>6.4</td><td>0.0</td><td>1</td><td>0</td><td>19.72</td></tr><tr><td>2024-04-21</td><td>8.8</td><td>0.0</td><td>1</td><td>0</td><td>20.18</td></tr><tr><td>2024-04-22</td><td>6.0</td><td>0.0</td><td>0</td><td>0</td><td>18.98</td></tr><tr><td>2024-04-23</td><td>7.3</td><td>0.0</td><td>0</td><td>0</td><td>18.94</td></tr><tr><td>2024-04-24</td><td>6.5</td><td>0.0</td><td>0</td><td>0</td><td>20.32</td></tr><tr><td>2024-04-25</td><td>9.1</td><td>0.0</td><td>0</td><td>0</td><td>21.01</td></tr><tr><td>2024-04-26</td><td>5.4</td><td>0.0</td><td>0</td><td>0</td><td>20.5</td></tr><tr><td>2024-04-27</td><td>14.1</td><td>0.0</td><td>1</td><td>0</td><td>20.47</td></tr><tr><td>2024-04-28</td><td>18.0</td><td>0.0</td><td>1</td><td>0</td><td>21.23</td></tr><tr><td>2024-04-29</td><td>15.0</td><td>0.0</td><td>0</td><td>0</td><td>20.94</td></tr><tr><td>2024-04-30</td><td>15.0</td><td>0.0</td><td>0</td><td>0</td><td>20.42</td></tr><tr><td>2024-05-01</td><td>15.9</td><td>0.0</td><td>1</td><td>0</td><td>20.01</td></tr><tr><td>2024-05-02</td><td>22.9</td><td>0.0</td><td>1</td><td>0</td><td>20.82</td></tr><tr><td>2024-05-03</td><td>21.8</td><td>0.0</td><td>1</td><td>0</td><td>21.1</td></tr><tr><td>2024-05-04</td><td>0.0</td><td>1.0</td><td>1</td><td>0</td><td>21.98</td></tr><tr><td>2024-05-05</td><td>21.0</td><td>0.0</td><td>1</td><td>0</td><td>20.71</td></tr><tr><td>2024-05-06</td><td>20.8</td><td>0.0</td><td>0</td><td>0</td><td>21.71</td></tr><tr><td>2024-05-07</td><td>20.8</td><td>0.0</td><td>0</td><td>0</td><td>20.66</td></tr><tr><td>2024-05-08</td><td>21.9</td><td>0.0</td><td>0</td><td>0</td><td>21.17</td></tr><tr><td>2024-05-09</td><td>25.3</td><td>0.0</td><td>0</td><td>0</td><td>21.54</td></tr><tr><td>2024-05-10</td><td>27.3</td><td>0.0</td><td>0</td><td>0</td><td>20.48</td></tr><tr><td>2024-05-11</td><td>29.4</td><td>0.0</td><td>1</td><td>0</td><td>21.41</td></tr><tr><td>2024-05-12</td><td>33.8</td><td>0.0</td><td>1</td><td>0</td><td>21.88</td></tr><tr><td>2024-05-13</td><td>25.7</td><td>0.0</td><td>0</td><td>0</td><td>21.59</td></tr><tr><td>2024-05-14</td><td>29.1</td><td>0.0</td><td>0</td><td>0</td><td>22.54</td></tr><tr><td>2024-05-15</td><td>24.4</td><td>0.0</td><td>0</td><td>0</td><td>22.19</td></tr><tr><td>2024-05-16</td><td>23.6</td><td>0.0</td><td>0</td><td>0</td><td>23.0</td></tr><tr><td>2024-05-17</td><td>0.0</td><td>1.0</td><td>0</td><td>0</td><td>23.18</td></tr><tr><td>2024-05-18</td><td>0.4</td><td>1.0</td><td>1</td><td>0</td><td>23.09</td></tr><tr><td>2024-05-19</td><td>31.9</td><td>0.0</td><td>1</td><td>0</td><td>23.53</td></tr><tr><td>2024-05-20</td><td>28.0</td><td>0.0</td><td>0</td><td>0</td><td>22.9</td></tr><tr><td>2024-05-21</td><td>28.9</td><td>0.0</td><td>0</td><td>0</td><td>22.72</td></tr><tr><td>2024-05-22</td><td>26.5</td><td>0.0</td><td>0</td><td>0</td><td>22.32</td></tr><tr><td>2024-05-23</td><td>25.4</td><td>0.0</td><td>0</td><td>0</td><td>23.39</td></tr><tr><td>2024-05-24</td><td>20.8</td><td>0.0</td><td>0</td><td>0</td><td>22.18</td></tr><tr><td>2024-05-25</td><td>31.7</td><td>0.0</td><td>1</td><td>0</td><td>22.99</td></tr><tr><td>2024-05-26</td><td>33.4</td><td>0.0</td><td>1</td><td>0</td><td>22.13</td></tr><tr><td>2024-05-27</td><td>31.4</td><td>0.0</td><td>0</td><td>0</td><td>21.63</td></tr><tr><td>2024-05-28</td><td>26.8</td><td>0.0</td><td>0</td><td>0</td><td>21.37</td></tr><tr><td>2024-05-29</td><td>24.5</td><td>0.0</td><td>0</td><td>0</td><td>21.51</td></tr><tr><td>2024-05-30</td><td>27.1</td><td>0.0</td><td>0</td><td>0</td><td>22.16</td></tr><tr><td>2024-05-31</td><td>28.7</td><td>0.0</td><td>0</td><td>0</td><td>22.2</td></tr><tr><td>2024-06-01</td><td>32.5</td><td>0.0</td><td>1</td><td>0</td><td>22.84</td></tr><tr><td>2024-06-02</td><td>29.2</td><td>0.0</td><td>1</td><td>0</td><td>22.95</td></tr><tr><td>2024-06-03</td><td>29.0</td><td>0.0</td><td>0</td><td>0</td><td>22.92</td></tr><tr><td>2024-06-04</td><td>27.5</td><td>0.0</td><td>0</td><td>0</td><td>23.92</td></tr><tr><td>2024-06-05</td><td>0.0</td><td>1.0</td><td>0</td><td>0</td><td>24.12</td></tr><tr><td>2024-06-06</td><td>27.8</td><td>0.0</td><td>0</td><td>0</td><td>24.27</td></tr><tr><td>2024-06-07</td><td>27.1</td><td>0.0</td><td>0</td><td>0</td><td>24.45</td></tr><tr><td>2024-06-08</td><td>32.9</td><td>0.0</td><td>1</td><td>0</td><td>24.38</td></tr><tr><td>2024-06-09</td><td>30.1</td><td>0.0</td><td>1</td><td>0</td><td>26.42</td></tr><tr><td>2024-06-10</td><td>40.2</td><td>0.0</td><td>1</td><td>0</td><td>25.51</td></tr><tr><td>2024-06-11</td><td>30.3</td><td>0.0</td><td>0</td><td>0</td><td>25.12</td></tr><tr><td>2024-06-12</td><td>29.4</td><td>0.0</td><td>0</td><td>0</td><td>25.33</td></tr><tr><td>2024-06-13</td><td>25.1</td><td>0.0</td><td>0</td><td>0</td><td>25.92</td></tr><tr><td>2024-06-14</td><td>26.0</td><td>0.0</td><td>0</td><td>0</td><td>26.54</td></tr><tr><td>2024-06-15</td><td>35.7</td><td>0.0</td><td>1</td><td>0</td><td>26.32</td></tr><tr><td>2024-06-16</td><td>35.0</td><td>0.0</td><td>1</td><td>0</td><td>27.54</td></tr><tr><td>2024-06-17</td><td>28.3</td><td>0.0</td><td>0</td><td>0</td><td>27.37</td></tr><tr><td>2024-06-18</td><td>28.9</td><td>0.0</td><td>0</td><td>0</td><td>27.58</td></tr><tr><td>2024-06-19</td><td>28.1</td><td>0.0</td><td>0</td><td>0</td><td>27.45</td></tr><tr><td>2024-06-20</td><td>31.5</td><td>0.0</td><td>0</td><td>0</td><td>28.35</td></tr><tr><td>2024-06-21</td><td>28.9</td><td>0.0</td><td>0</td><td>0</td><td>27.78</td></tr><tr><td>2024-06-22</td><td>41.2</td><td>0.0</td><td>1</td><td>0</td><td>28.43</td></tr><tr><td>2024-06-23</td><td>34.5</td><td>0.0</td><td>1</td><td>0</td><td>28.06</td></tr><tr><td>2024-06-24</td><td>33.6</td><td>0.0</td><td>0</td><td>0</td><td>27.41</td></tr><tr><td>2024-06-25</td><td>34.6</td><td>0.0</td><td>0</td><td>0</td><td>28.55</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         "2024-03-28",
+         3.8,
+         0.0,
+         0,
+         0,
+         16.77
+        ],
+        [
+         "2024-03-29",
+         2.4,
+         0.0,
+         0,
+         0,
+         16.52
+        ],
+        [
+         "2024-03-30",
+         6.0,
+         0.0,
+         1,
+         0,
+         16.86
+        ],
+        [
+         "2024-03-31",
+         3.3,
+         0.0,
+         1,
+         0,
+         16.93
+        ],
+        [
+         "2024-04-01",
+         3.0,
+         0.0,
+         0,
+         0,
+         16.51
+        ],
+        [
+         "2024-04-02",
+         3.0,
+         0.0,
+         0,
+         0,
+         17.64
+        ],
+        [
+         "2024-04-03",
+         3.0,
+         0.0,
+         0,
+         0,
+         17.89
+        ],
+        [
+         "2024-04-04",
+         4.3,
+         0.0,
+         1,
+         0,
+         16.64
+        ],
+        [
+         "2024-04-05",
+         3.6,
+         0.0,
+         1,
+         0,
+         16.66
+        ],
+        [
+         "2024-04-06",
+         5.3,
+         0.0,
+         1,
+         0,
+         17.79
+        ],
+        [
+         "2024-04-07",
+         3.0,
+         0.0,
+         0,
+         0,
+         18.03
+        ],
+        [
+         "2024-04-08",
+         3.5,
+         0.0,
+         0,
+         0,
+         17.23
+        ],
+        [
+         "2024-04-09",
+         3.6,
+         0.0,
+         0,
+         0,
+         18.47
+        ],
+        [
+         "2024-04-10",
+         3.8,
+         0.0,
+         0,
+         0,
+         18.14
+        ],
+        [
+         "2024-04-11",
+         6.1,
+         0.0,
+         0,
+         0,
+         18.51
+        ],
+        [
+         "2024-04-12",
+         3.4,
+         0.0,
+         0,
+         0,
+         18.62
+        ],
+        [
+         "2024-04-13",
+         4.8,
+         0.0,
+         1,
+         0,
+         18.98
+        ],
+        [
+         "2024-04-14",
+         6.0,
+         0.0,
+         1,
+         0,
+         18.51
+        ],
+        [
+         "2024-04-15",
+         6.0,
+         0.0,
+         0,
+         0,
+         18.6
+        ],
+        [
+         "2024-04-16",
+         6.0,
+         0.0,
+         0,
+         0,
+         18.61
+        ],
+        [
+         "2024-04-17",
+         5.8,
+         0.0,
+         0,
+         0,
+         18.82
+        ],
+        [
+         "2024-04-18",
+         5.4,
+         0.0,
+         0,
+         0,
+         18.65
+        ],
+        [
+         "2024-04-19",
+         6.0,
+         0.0,
+         0,
+         0,
+         19.08
+        ],
+        [
+         "2024-04-20",
+         6.4,
+         0.0,
+         1,
+         0,
+         19.72
+        ],
+        [
+         "2024-04-21",
+         8.8,
+         0.0,
+         1,
+         0,
+         20.18
+        ],
+        [
+         "2024-04-22",
+         6.0,
+         0.0,
+         0,
+         0,
+         18.98
+        ],
+        [
+         "2024-04-23",
+         7.3,
+         0.0,
+         0,
+         0,
+         18.94
+        ],
+        [
+         "2024-04-24",
+         6.5,
+         0.0,
+         0,
+         0,
+         20.32
+        ],
+        [
+         "2024-04-25",
+         9.1,
+         0.0,
+         0,
+         0,
+         21.01
+        ],
+        [
+         "2024-04-26",
+         5.4,
+         0.0,
+         0,
+         0,
+         20.5
+        ],
+        [
+         "2024-04-27",
+         14.1,
+         0.0,
+         1,
+         0,
+         20.47
+        ],
+        [
+         "2024-04-28",
+         18.0,
+         0.0,
+         1,
+         0,
+         21.23
+        ],
+        [
+         "2024-04-29",
+         15.0,
+         0.0,
+         0,
+         0,
+         20.94
+        ],
+        [
+         "2024-04-30",
+         15.0,
+         0.0,
+         0,
+         0,
+         20.42
+        ],
+        [
+         "2024-05-01",
+         15.9,
+         0.0,
+         1,
+         0,
+         20.01
+        ],
+        [
+         "2024-05-02",
+         22.9,
+         0.0,
+         1,
+         0,
+         20.82
+        ],
+        [
+         "2024-05-03",
+         21.8,
+         0.0,
+         1,
+         0,
+         21.1
+        ],
+        [
+         "2024-05-04",
+         0.0,
+         1.0,
+         1,
+         0,
+         21.98
+        ],
+        [
+         "2024-05-05",
+         21.0,
+         0.0,
+         1,
+         0,
+         20.71
+        ],
+        [
+         "2024-05-06",
+         20.8,
+         0.0,
+         0,
+         0,
+         21.71
+        ],
+        [
+         "2024-05-07",
+         20.8,
+         0.0,
+         0,
+         0,
+         20.66
+        ],
+        [
+         "2024-05-08",
+         21.9,
+         0.0,
+         0,
+         0,
+         21.17
+        ],
+        [
+         "2024-05-09",
+         25.3,
+         0.0,
+         0,
+         0,
+         21.54
+        ],
+        [
+         "2024-05-10",
+         27.3,
+         0.0,
+         0,
+         0,
+         20.48
+        ],
+        [
+         "2024-05-11",
+         29.4,
+         0.0,
+         1,
+         0,
+         21.41
+        ],
+        [
+         "2024-05-12",
+         33.8,
+         0.0,
+         1,
+         0,
+         21.88
+        ],
+        [
+         "2024-05-13",
+         25.7,
+         0.0,
+         0,
+         0,
+         21.59
+        ],
+        [
+         "2024-05-14",
+         29.1,
+         0.0,
+         0,
+         0,
+         22.54
+        ],
+        [
+         "2024-05-15",
+         24.4,
+         0.0,
+         0,
+         0,
+         22.19
+        ],
+        [
+         "2024-05-16",
+         23.6,
+         0.0,
+         0,
+         0,
+         23.0
+        ],
+        [
+         "2024-05-17",
+         0.0,
+         1.0,
+         0,
+         0,
+         23.18
+        ],
+        [
+         "2024-05-18",
+         0.4,
+         1.0,
+         1,
+         0,
+         23.09
+        ],
+        [
+         "2024-05-19",
+         31.9,
+         0.0,
+         1,
+         0,
+         23.53
+        ],
+        [
+         "2024-05-20",
+         28.0,
+         0.0,
+         0,
+         0,
+         22.9
+        ],
+        [
+         "2024-05-21",
+         28.9,
+         0.0,
+         0,
+         0,
+         22.72
+        ],
+        [
+         "2024-05-22",
+         26.5,
+         0.0,
+         0,
+         0,
+         22.32
+        ],
+        [
+         "2024-05-23",
+         25.4,
+         0.0,
+         0,
+         0,
+         23.39
+        ],
+        [
+         "2024-05-24",
+         20.8,
+         0.0,
+         0,
+         0,
+         22.18
+        ],
+        [
+         "2024-05-25",
+         31.7,
+         0.0,
+         1,
+         0,
+         22.99
+        ],
+        [
+         "2024-05-26",
+         33.4,
+         0.0,
+         1,
+         0,
+         22.13
+        ],
+        [
+         "2024-05-27",
+         31.4,
+         0.0,
+         0,
+         0,
+         21.63
+        ],
+        [
+         "2024-05-28",
+         26.8,
+         0.0,
+         0,
+         0,
+         21.37
+        ],
+        [
+         "2024-05-29",
+         24.5,
+         0.0,
+         0,
+         0,
+         21.51
+        ],
+        [
+         "2024-05-30",
+         27.1,
+         0.0,
+         0,
+         0,
+         22.16
+        ],
+        [
+         "2024-05-31",
+         28.7,
+         0.0,
+         0,
+         0,
+         22.2
+        ],
+        [
+         "2024-06-01",
+         32.5,
+         0.0,
+         1,
+         0,
+         22.84
+        ],
+        [
+         "2024-06-02",
+         29.2,
+         0.0,
+         1,
+         0,
+         22.95
+        ],
+        [
+         "2024-06-03",
+         29.0,
+         0.0,
+         0,
+         0,
+         22.92
+        ],
+        [
+         "2024-06-04",
+         27.5,
+         0.0,
+         0,
+         0,
+         23.92
+        ],
+        [
+         "2024-06-05",
+         0.0,
+         1.0,
+         0,
+         0,
+         24.12
+        ],
+        [
+         "2024-06-06",
+         27.8,
+         0.0,
+         0,
+         0,
+         24.27
+        ],
+        [
+         "2024-06-07",
+         27.1,
+         0.0,
+         0,
+         0,
+         24.45
+        ],
+        [
+         "2024-06-08",
+         32.9,
+         0.0,
+         1,
+         0,
+         24.38
+        ],
+        [
+         "2024-06-09",
+         30.1,
+         0.0,
+         1,
+         0,
+         26.42
+        ],
+        [
+         "2024-06-10",
+         40.2,
+         0.0,
+         1,
+         0,
+         25.51
+        ],
+        [
+         "2024-06-11",
+         30.3,
+         0.0,
+         0,
+         0,
+         25.12
+        ],
+        [
+         "2024-06-12",
+         29.4,
+         0.0,
+         0,
+         0,
+         25.33
+        ],
+        [
+         "2024-06-13",
+         25.1,
+         0.0,
+         0,
+         0,
+         25.92
+        ],
+        [
+         "2024-06-14",
+         26.0,
+         0.0,
+         0,
+         0,
+         26.54
+        ],
+        [
+         "2024-06-15",
+         35.7,
+         0.0,
+         1,
+         0,
+         26.32
+        ],
+        [
+         "2024-06-16",
+         35.0,
+         0.0,
+         1,
+         0,
+         27.54
+        ],
+        [
+         "2024-06-17",
+         28.3,
+         0.0,
+         0,
+         0,
+         27.37
+        ],
+        [
+         "2024-06-18",
+         28.9,
+         0.0,
+         0,
+         0,
+         27.58
+        ],
+        [
+         "2024-06-19",
+         28.1,
+         0.0,
+         0,
+         0,
+         27.45
+        ],
+        [
+         "2024-06-20",
+         31.5,
+         0.0,
+         0,
+         0,
+         28.35
+        ],
+        [
+         "2024-06-21",
+         28.9,
+         0.0,
+         0,
+         0,
+         27.78
+        ],
+        [
+         "2024-06-22",
+         41.2,
+         0.0,
+         1,
+         0,
+         28.43
+        ],
+        [
+         "2024-06-23",
+         34.5,
+         0.0,
+         1,
+         0,
+         28.06
+        ],
+        [
+         "2024-06-24",
+         33.6,
+         0.0,
+         0,
+         0,
+         27.41
+        ],
+        [
+         "2024-06-25",
+         34.6,
+         0.0,
+         0,
+         0,
+         28.55
+        ]
+       ],
+       "datasetInfos": [
+        {
+         "name": "_sqldf",
+         "schema": {
+          "fields": [
+           {
+            "metadata": {},
+            "name": "ds",
+            "nullable": true,
+            "type": "date"
+           },
+           {
+            "metadata": {},
+            "name": "y",
+            "nullable": true,
+            "type": "double"
+           },
+           {
+            "metadata": {},
+            "name": "discount",
+            "nullable": true,
+            "type": "double"
+           },
+           {
+            "metadata": {},
+            "name": "holiday_flag",
+            "nullable": true,
+            "type": "integer"
+           },
+           {
+            "metadata": {},
+            "name": "activity_flag",
+            "nullable": true,
+            "type": "integer"
+           },
+           {
+            "metadata": {},
+            "name": "avg_temperature",
+            "nullable": true,
+            "type": "double"
+           }
+          ],
+          "type": "struct"
+         },
+         "tableIdentifier": null,
+         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
+        }
+       ],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {
+        "createTempViewForImplicitDf": true,
+        "dataframeName": "_sqldf",
+        "executionCount": 9
+       },
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "ds",
+         "type": "\"date\""
+        },
+        {
+         "metadata": "{}",
+         "name": "y",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "discount",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "holiday_flag",
+         "type": "\"integer\""
+        },
+        {
+         "metadata": "{}",
+         "name": "activity_flag",
+         "type": "\"integer\""
+        },
+        {
+         "metadata": "{}",
+         "name": "avg_temperature",
+         "type": "\"double\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%sql\n",
+    "-- Sample time series for the top-demand series (train only)\n",
+    "SELECT ds, y, discount, holiday_flag, activity_flag, avg_temperature\n",
+    "FROM mmf.fresh_retail_net.demand_train\n",
+    "WHERE unique_id = (\n",
+    "  SELECT unique_id\n",
+    "  FROM mmf.fresh_retail_net.demand_train\n",
+    "  GROUP BY unique_id\n",
+    "  ORDER BY SUM(y) DESC\n",
+    "  LIMIT 1\n",
+    ")\n",
+    "ORDER BY ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "6db206d0-5357-4b19-85b8-26f957837f31",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## Output Tables\n",
+    "\n",
+    "### `mmf.fresh_retail_net.demand_train` — Training data (1,000 series x 90 days)\n",
+    "\n",
+    "| Column | Type | MMF Role | Description |\n",
+    "|---|---|---|---|\n",
+    "| `unique_id` | STRING | **Group ID** | `{store_id}_{product_id}` — the forecasting unit |\n",
+    "| `ds` | DATE | **Time column** | Date (daily, no gaps) |\n",
+    "| `y` | DOUBLE | **Target** | Daily sales amount (normalized) |\n",
+    "| `discount` | DOUBLE | Regressor | Discount rate (1.0 = no discount) |\n",
+    "| `holiday_flag` | INT | Regressor | Holiday indicator |\n",
+    "| `activity_flag` | INT | Regressor | Promotion indicator |\n",
+    "| `precpt` | DOUBLE | Regressor | Precipitation |\n",
+    "| `avg_temperature` | DOUBLE | Regressor | Average temperature |\n",
+    "| `avg_humidity` | DOUBLE | Regressor | Average humidity |\n",
+    "| `avg_wind_level` | DOUBLE | Regressor | Average wind level |\n",
+    "| `stock_hour6_22_cnt` | INT | Info | Out-of-stock hours (6am–10pm) |\n",
+    "| `city_id` | INT | Grouping | City |\n",
+    "| `store_id` | INT | Grouping | Store |\n",
+    "| `product_id` | INT | Grouping | Product |\n",
+    "| `management_group_id` | INT | Grouping | Management group |\n",
+    "| `first_category_id` | INT | Grouping | Product category L1 |\n",
+    "| `second_category_id` | INT | Grouping | Product category L2 |\n",
+    "| `third_category_id` | INT | Grouping | Product category L3 |\n",
+    "\n",
+    "### `mmf.fresh_retail_net.demand_score` — Scoring data (1,000 series x 7 days)\n",
+    "\n",
+    "Same columns as train **except `y` is excluded** (this is what MMF will predict).\n",
+    "\n",
+    "### Example MMF `run_forecast` call:\n",
+    "```python\n",
+    "run_forecast(\n",
+    "    spark=spark,\n",
+    "    train_data=\"mmf.fresh_retail_net.demand_train\",\n",
+    "    scoring_data=\"mmf.fresh_retail_net.demand_score\",\n",
+    "    scoring_output=\"mmf.fresh_retail_net.scoring_output\",\n",
+    "    evaluation_output=\"mmf.fresh_retail_net.evaluation_output\",\n",
+    "    group_id=\"unique_id\",\n",
+    "    date_col=\"ds\",\n",
+    "    target=\"y\",\n",
+    "    freq=\"D\",\n",
+    "    prediction_length=7,\n",
+    "    backtest_length=14,\n",
+    "    stride=7,\n",
+    "    metric=\"smape\",\n",
+    "    train_predict_ratio=2,\n",
+    "    dynamic_future_numerical=[\"discount\", \"precpt\", \"avg_temperature\", \"avg_humidity\", \"avg_wind_level\"],\n",
+    "    dynamic_future_categorical=[\"holiday_flag\", \"activity_flag\"],\n",
+    ")\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": null,
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": 6974427467250226,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
+    "pythonIndentUnit": 2
+   },
+   "notebookName": "fresh_retail_net_data_prep",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/fresh_retail_net/02_fresh_retail_net_mmf_forecast.ipynb
+++ b/examples/fresh_retail_net/02_fresh_retail_net_mmf_forecast.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -71,16 +71,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001B[33mWARNING: huggingface-hub 1.19.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.19.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.18.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.18.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.17.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.17.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.15.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.15.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.14.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.14.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.13.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.13.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.11.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.11.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.8.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.8.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.6.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.6.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.5.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.5.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.4.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.4.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.4.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.4.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.7 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.7 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.5 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.5 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.7 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.7 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.6 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.6 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.5 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.5 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.0.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.0.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.0.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.0.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\ndatabricks-serverless-gpu 0.5.11+patch5 requires databricks-connect<16,>=15.4.2, but you have databricks-connect 17.3.8 which is incompatible.\ndatabricks-serverless-gpu 0.5.11+patch5 requires mlflow<3.0,>=2.17, but you have mlflow 3.13.0 which is incompatible.\u001B[0m\u001B[31m\n\u001B[0m\u001B[43mNote: you may need to restart the kernel using %restart_python or dbutils.library.restartPython() to use updated packages.\u001B[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install \"mmf_sa[foundation] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git\" hf_transfer --quiet\n",
     "dbutils.library.restartPython()"
@@ -107,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -124,16 +115,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Train rows: 90,000  |  Score rows: 7,000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import logging\n",
     "import uuid\n",
@@ -174,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -191,16 +173,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Models to run: 3\n  - ChronosBoltBase\n  - Chronos2\n  - TimesFM_2_5_200m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "active_models = [\n",
     "    \"ChronosBoltBase\",\n",
@@ -238,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -255,389 +228,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n============================================================\nRunning ChronosBoltBase (run_id=772b28cf-b3e3-4001-93ec-3b7ce17db099)\n============================================================\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026/06/11 19:53:35 INFO mlflow.tracking.fluent: Experiment with name '/Users/visvenky@amazon.com/mmf/fresh_retail_net' does not exist. Creating a new experiment.\n\u001B[1;38;5;208mIf you are using MLflow Tracing, consider storing your traces in Unity Catalog for unlimited storage (no 100,000 trace limit), fine-grained access controls, and queryability from notebooks, SQL, and dashboards. \u001B[94mLearn more: https://docs.databricks.com/aws/en/mlflow3/genai/tracing/trace-unity-catalog\u001B[0m\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Run quality checks\nFinished quality checks\nStarting evaluate_score\nStarting evaluate_models\nStarted evaluating ChronosBoltBase\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/system_metrics/metrics/gpu_monitor.py:11: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.\n  import pynvml\n2026/06/11 19:53:39 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:156: FutureWarning: Model's `predict` method contains invalid parameters: {'input_data'}. Only the following parameter names are allowed: context, model_input, and params. Note that invalid parameters will no longer be permitted in future versions.\n  param_names = _check_func_signature(func, \"predict\")\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:187: UserWarning: \u001B[33mAdd type hints to the `predict` method to enable data validation and automatic signature inference during model logging. Check https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel for more details.\u001B[0m\n  color_warning(\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:156: FutureWarning: Model's `predict` method contains invalid parameters: {'input_data'}. Only the following parameter names are allowed: context, model_input, and params. Note that invalid parameters will no longer be permitted in future versions.\n  param_names = _check_func_signature(func, \"predict\")\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:187: UserWarning: \u001B[33mAdd type hints to the `predict` method to enable data validation and automatic signature inference during model logging. Check https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel for more details.\u001B[0m\n  color_warning(\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "aff5b8441c0a4270adb3206a3f3e321e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "config.json: 0.00B [00:00, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2e509747d9034a3d818d13b5d0b81d2a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "model.safetensors:   0%|          | 0.00/821M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026/06/11 19:54:07 WARNING mlflow.models.model: `artifact_path` is deprecated. Please use `name` instead.\n\uD83D\uDD17 View Logged Model at: https://aws-daisdemo.cloud.databricks.com/ml/experiments/3276803282238396/models/m-2e58f1d038cb4267a2fea50851bb2897?o=7474649743221542\n2026/06/11 19:54:10 INFO mlflow.pyfunc: Validating input example against model signature\nSuccessfully registered model 'mmf.fresh_retail_net.chronosboltbase_fresh_retail_net'.\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "287e065498004f3baeb6b4e3c1b88dc0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Uploading artifacts:   0%|          | 0/11 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\uD83D\uDD17 Created version '1' of model 'mmf.fresh_retail_net.chronosboltbase_fresh_retail_net': https://aws-daisdemo.cloud.databricks.com/explore/data/models/mmf/fresh_retail_net/chronosboltbase_fresh_retail_net/version/1?o=7474649743221542\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  metric_name  metric_value\n0       smape       0.46902\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026/06/11 19:55:15 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n2026/06/11 19:55:16 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finished evaluating ChronosBoltBase\nFinished evaluate_models\nStarting run_scoring\nStarted scoring with ChronosBoltBase\nRunning scoring for ChronosBoltBase...\nFinished scoring with ChronosBoltBase\nFinished run_scoring\nFinished evaluate_score\n\n============================================================\nRunning Chronos2 (run_id=772b28cf-b3e3-4001-93ec-3b7ce17db099)\n============================================================\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001B[1;38;5;208mIf you are using MLflow Tracing, you can migrate your traces to Unity Catalog for unlimited storage, fine-grained access controls, and queryability from notebooks, SQL, and dashboards. \u001B[94mLearn more: https://docs.databricks.com/aws/en/mlflow3/genai/tracing/migrate-traces-to-uc\u001B[0m\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Run quality checks\nFinished quality checks\nStarting evaluate_score\nStarting evaluate_models\nStarted evaluating Chronos2\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026/06/11 19:55:36 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9d6176fc66d44b35b3bf7bbb32bfb217",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "config.json: 0.00B [00:00, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "709b6da2ac6f4dc6a2b4f1a4169b72b9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "model.safetensors:   0%|          | 0.00/478M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026/06/11 19:55:42 WARNING mlflow.models.model: `artifact_path` is deprecated. Please use `name` instead.\n\uD83D\uDD17 View Logged Model at: https://aws-daisdemo.cloud.databricks.com/ml/experiments/3276803282238396/models/m-6084f8769dac4ddfa565272c398c8124?o=7474649743221542\n2026/06/11 19:55:42 INFO mlflow.pyfunc: Validating input example against model signature\nSuccessfully registered model 'mmf.fresh_retail_net.chronos2_fresh_retail_net'.\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "360245535ea843b1bbddc8abaa869a52",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Uploading artifacts:   0%|          | 0/11 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\uD83D\uDD17 Created version '1' of model 'mmf.fresh_retail_net.chronos2_fresh_retail_net': https://aws-daisdemo.cloud.databricks.com/explore/data/models/mmf/fresh_retail_net/chronos2_fresh_retail_net/version/1?o=7474649743221542\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  metric_name  metric_value\n0       smape      0.471685\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026/06/11 19:56:57 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n2026/06/11 19:56:57 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finished evaluating Chronos2\nFinished evaluate_models\nStarting run_scoring\nStarted scoring with Chronos2\nRunning scoring for Chronos2...\nFinished scoring with Chronos2\nFinished run_scoring\nFinished evaluate_score\n\n============================================================\nRunning TimesFM_2_5_200m (run_id=772b28cf-b3e3-4001-93ec-3b7ce17db099)\n============================================================\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001B[1;38;5;208mIf you are using MLflow Tracing, you can migrate your traces to Unity Catalog for unlimited storage, fine-grained access controls, and queryability from notebooks, SQL, and dashboards. \u001B[94mLearn more: https://docs.databricks.com/aws/en/mlflow3/genai/tracing/migrate-traces-to-uc\u001B[0m\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Run quality checks\nFinished quality checks\nStarting evaluate_score\nStarting evaluate_models\nStarted evaluating TimesFM_2_5_200m\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026/06/11 19:57:33 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:156: FutureWarning: Model's `predict` method contains invalid parameters: {'input_data'}. Only the following parameter names are allowed: context, model_input, and params. Note that invalid parameters will no longer be permitted in future versions.\n  param_names = _check_func_signature(func, \"predict\")\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:187: UserWarning: \u001B[33mAdd type hints to the `predict` method to enable data validation and automatic signature inference during model logging. Check https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel for more details.\u001B[0m\n  color_warning(\n2026/06/11 19:57:35 WARNING mlflow.models.model: `artifact_path` is deprecated. Please use `name` instead.\n\uD83D\uDD17 View Logged Model at: https://aws-daisdemo.cloud.databricks.com/ml/experiments/3276803282238396/models/m-ec85d6d898814975ad8bf3c1513ad6f2?o=7474649743221542\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/__init__.py:3341: UserWarning: \u001B[1;33mAn input example was not provided when logging the model. To ensure the model signature functions correctly, specify the `input_example` parameter. See https://mlflow.org/docs/latest/model/signatures.html#model-input-example for more details about the benefits of using input_example.\u001B[0m\n  color_warning(\nSuccessfully registered model 'mmf.fresh_retail_net.timesfm_2_5_200m_fresh_retail_net'.\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9e8d90b2d6f54e97a3dad225d34bb80f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Uploading artifacts:   0%|          | 0/9 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\uD83D\uDD17 Created version '1' of model 'mmf.fresh_retail_net.timesfm_2_5_200m_fresh_retail_net': https://aws-daisdemo.cloud.databricks.com/explore/data/models/mmf/fresh_retail_net/timesfm_2_5_200m_fresh_retail_net/version/1?o=7474649743221542\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b432bd332dd14d92988633acadb44077",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "config.json:   0%|          | 0.00/475 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "58c4d6ad9d9a4fdc9deb4eeb6b274fe8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "config.json:   0%|          | 0.00/475 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloaded.\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d11830e828c44d96bbfa885d29ca0347",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "model.safetensors:   0%|          | 0.00/925M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  metric_name  metric_value\n0       smape      0.453783\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026/06/11 19:58:12 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n2026/06/11 19:58:12 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Finished evaluating TimesFM_2_5_200m\nFinished evaluate_models\nStarting run_scoring\nStarted scoring with TimesFM_2_5_200m\nRunning scoring for TimesFM_2_5_200m...\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:mmf_sa.data_quality_checks:External regressors detected, checking resampling configuration\nINFO:mmf_sa.data_quality_checks:External regressors configuration validation passed\n"
-     ]
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3e9eb1a4ae2b450daaec32ebe796e75e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "config.json:   0%|          | 0.00/475 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloaded.\nFinished scoring with TimesFM_2_5_200m\nFinished run_scoring\nFinished evaluate_score\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from mmf_sa import run_forecast\n",
     "\n",
@@ -698,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -716,141 +307,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/html": [
-       "<style scoped>\n",
-       "  .table-result-container {\n",
-       "    max-height: 300px;\n",
-       "    overflow: auto;\n",
-       "  }\n",
-       "  table, th, td {\n",
-       "    border: 1px solid black;\n",
-       "    border-collapse: collapse;\n",
-       "  }\n",
-       "  th, td {\n",
-       "    padding: 5px;\n",
-       "  }\n",
-       "  th {\n",
-       "    text-align: left;\n",
-       "  }\n",
-       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>model</th><th>num_series</th><th>avg_smape</th><th>median_smape</th></tr></thead><tbody><tr><td>TimesFM_2_5_200m</td><td>1000</td><td>0.4538</td><td>0.3812</td></tr><tr><td>ChronosBoltBase</td><td>1000</td><td>0.469</td><td>0.394</td></tr><tr><td>Chronos2</td><td>1000</td><td>0.4717</td><td>0.3988</td></tr></tbody></table></div>"
-      ]
-     },
-     "metadata": {
-      "application/vnd.databricks.v1+output": {
-       "addedWidgets": {},
-       "aggData": [],
-       "aggError": "",
-       "aggOverflow": false,
-       "aggSchema": [],
-       "aggSeriesLimitReached": false,
-       "aggType": "",
-       "arguments": {},
-       "columnCustomDisplayInfos": {},
-       "data": [
-        [
-         "TimesFM_2_5_200m",
-         1000,
-         0.4538,
-         0.3812
-        ],
-        [
-         "ChronosBoltBase",
-         1000,
-         0.469,
-         0.394
-        ],
-        [
-         "Chronos2",
-         1000,
-         0.4717,
-         0.3988
-        ]
-       ],
-       "datasetInfos": [
-        {
-         "name": "_sqldf",
-         "schema": {
-          "fields": [
-           {
-            "metadata": {},
-            "name": "model",
-            "nullable": true,
-            "type": "string"
-           },
-           {
-            "metadata": {},
-            "name": "num_series",
-            "nullable": false,
-            "type": "long"
-           },
-           {
-            "metadata": {},
-            "name": "avg_smape",
-            "nullable": true,
-            "type": "double"
-           },
-           {
-            "metadata": {},
-            "name": "median_smape",
-            "nullable": true,
-            "type": "double"
-           }
-          ],
-          "type": "struct"
-         },
-         "tableIdentifier": null,
-         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
-        }
-       ],
-       "dbfsResultPath": null,
-       "isJsonSchema": true,
-       "metadata": {
-        "createTempViewForImplicitDf": true,
-        "dataframeName": "_sqldf",
-        "executionCount": 4
-       },
-       "overflow": false,
-       "plotOptions": {
-        "customPlotOptions": {},
-        "displayType": "table",
-        "pivotAggregation": null,
-        "pivotColumns": null,
-        "xColumns": null,
-        "yColumns": null
-       },
-       "removedWidgets": [],
-       "schema": [
-        {
-         "metadata": "{}",
-         "name": "model",
-         "type": "\"string\""
-        },
-        {
-         "metadata": "{}",
-         "name": "num_series",
-         "type": "\"long\""
-        },
-        {
-         "metadata": "{}",
-         "name": "avg_smape",
-         "type": "\"double\""
-        },
-        {
-         "metadata": "{}",
-         "name": "median_smape",
-         "type": "\"double\""
-        }
-       ],
-       "type": "table"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%sql\n",
     "SELECT\n",
@@ -884,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -902,211 +359,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/html": [
-       "<style scoped>\n",
-       "  .table-result-container {\n",
-       "    max-height: 300px;\n",
-       "    overflow: auto;\n",
-       "  }\n",
-       "  table, th, td {\n",
-       "    border: 1px solid black;\n",
-       "    border-collapse: collapse;\n",
-       "  }\n",
-       "  th, td {\n",
-       "    padding: 5px;\n",
-       "  }\n",
-       "  th {\n",
-       "    text-align: left;\n",
-       "  }\n",
-       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>model</th><th>num_series</th><th>total_predictions</th><th>min_date</th><th>max_date</th></tr></thead><tbody><tr><td>Chronos2</td><td>1000</td><td>1000</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td></tr><tr><td>ChronosBoltBase</td><td>1000</td><td>1000</td><td>List(2024-07-03T00:00:00.000Z, 2024-07-04T00:00:00.000Z, 2024-07-05T00:00:00.000Z, 2024-07-06T00:00:00.000Z, 2024-07-07T00:00:00.000Z, 2024-07-08T00:00:00.000Z, 2024-07-09T00:00:00.000Z)</td><td>List(2024-07-03T00:00:00.000Z, 2024-07-04T00:00:00.000Z, 2024-07-05T00:00:00.000Z, 2024-07-06T00:00:00.000Z, 2024-07-07T00:00:00.000Z, 2024-07-08T00:00:00.000Z, 2024-07-09T00:00:00.000Z)</td></tr><tr><td>TimesFM_2_5_200m</td><td>1000</td><td>1000</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td></tr></tbody></table></div>"
-      ]
-     },
-     "metadata": {
-      "application/vnd.databricks.v1+output": {
-       "addedWidgets": {},
-       "aggData": [],
-       "aggError": "",
-       "aggOverflow": false,
-       "aggSchema": [],
-       "aggSeriesLimitReached": false,
-       "aggType": "",
-       "arguments": {},
-       "columnCustomDisplayInfos": {},
-       "data": [
-        [
-         "Chronos2",
-         1000,
-         1000,
-         [
-          "2024-06-26T00:00:00.000Z",
-          "2024-06-27T00:00:00.000Z",
-          "2024-06-28T00:00:00.000Z",
-          "2024-06-29T00:00:00.000Z",
-          "2024-06-30T00:00:00.000Z",
-          "2024-07-01T00:00:00.000Z",
-          "2024-07-02T00:00:00.000Z"
-         ],
-         [
-          "2024-06-26T00:00:00.000Z",
-          "2024-06-27T00:00:00.000Z",
-          "2024-06-28T00:00:00.000Z",
-          "2024-06-29T00:00:00.000Z",
-          "2024-06-30T00:00:00.000Z",
-          "2024-07-01T00:00:00.000Z",
-          "2024-07-02T00:00:00.000Z"
-         ]
-        ],
-        [
-         "ChronosBoltBase",
-         1000,
-         1000,
-         [
-          "2024-07-03T00:00:00.000Z",
-          "2024-07-04T00:00:00.000Z",
-          "2024-07-05T00:00:00.000Z",
-          "2024-07-06T00:00:00.000Z",
-          "2024-07-07T00:00:00.000Z",
-          "2024-07-08T00:00:00.000Z",
-          "2024-07-09T00:00:00.000Z"
-         ],
-         [
-          "2024-07-03T00:00:00.000Z",
-          "2024-07-04T00:00:00.000Z",
-          "2024-07-05T00:00:00.000Z",
-          "2024-07-06T00:00:00.000Z",
-          "2024-07-07T00:00:00.000Z",
-          "2024-07-08T00:00:00.000Z",
-          "2024-07-09T00:00:00.000Z"
-         ]
-        ],
-        [
-         "TimesFM_2_5_200m",
-         1000,
-         1000,
-         [
-          "2024-06-26T00:00:00.000Z",
-          "2024-06-27T00:00:00.000Z",
-          "2024-06-28T00:00:00.000Z",
-          "2024-06-29T00:00:00.000Z",
-          "2024-06-30T00:00:00.000Z",
-          "2024-07-01T00:00:00.000Z",
-          "2024-07-02T00:00:00.000Z"
-         ],
-         [
-          "2024-06-26T00:00:00.000Z",
-          "2024-06-27T00:00:00.000Z",
-          "2024-06-28T00:00:00.000Z",
-          "2024-06-29T00:00:00.000Z",
-          "2024-06-30T00:00:00.000Z",
-          "2024-07-01T00:00:00.000Z",
-          "2024-07-02T00:00:00.000Z"
-         ]
-        ]
-       ],
-       "datasetInfos": [
-        {
-         "name": "_sqldf",
-         "schema": {
-          "fields": [
-           {
-            "metadata": {},
-            "name": "model",
-            "nullable": true,
-            "type": "string"
-           },
-           {
-            "metadata": {},
-            "name": "num_series",
-            "nullable": false,
-            "type": "long"
-           },
-           {
-            "metadata": {},
-            "name": "total_predictions",
-            "nullable": false,
-            "type": "long"
-           },
-           {
-            "metadata": {},
-            "name": "min_date",
-            "nullable": true,
-            "type": {
-             "containsNull": true,
-             "elementType": "timestamp",
-             "type": "array"
-            }
-           },
-           {
-            "metadata": {},
-            "name": "max_date",
-            "nullable": true,
-            "type": {
-             "containsNull": true,
-             "elementType": "timestamp",
-             "type": "array"
-            }
-           }
-          ],
-          "type": "struct"
-         },
-         "tableIdentifier": null,
-         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
-        }
-       ],
-       "dbfsResultPath": null,
-       "isJsonSchema": true,
-       "metadata": {
-        "createTempViewForImplicitDf": true,
-        "dataframeName": "_sqldf",
-        "executionCount": 5
-       },
-       "overflow": false,
-       "plotOptions": {
-        "customPlotOptions": {},
-        "displayType": "table",
-        "pivotAggregation": null,
-        "pivotColumns": null,
-        "xColumns": null,
-        "yColumns": null
-       },
-       "removedWidgets": [],
-       "schema": [
-        {
-         "metadata": "{}",
-         "name": "model",
-         "type": "\"string\""
-        },
-        {
-         "metadata": "{}",
-         "name": "num_series",
-         "type": "\"long\""
-        },
-        {
-         "metadata": "{}",
-         "name": "total_predictions",
-         "type": "\"long\""
-        },
-        {
-         "metadata": "{}",
-         "name": "min_date",
-         "type": "{\"containsNull\":true,\"elementType\":\"timestamp\",\"type\":\"array\"}"
-        },
-        {
-         "metadata": "{}",
-         "name": "max_date",
-         "type": "{\"containsNull\":true,\"elementType\":\"timestamp\",\"type\":\"array\"}"
-        }
-       ],
-       "type": "table"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%sql\n",
     "SELECT\n",
@@ -1122,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -1140,197 +393,7 @@
      "title": ""
     }
    },
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/html": [
-       "<style scoped>\n",
-       "  .table-result-container {\n",
-       "    max-height: 300px;\n",
-       "    overflow: auto;\n",
-       "  }\n",
-       "  table, th, td {\n",
-       "    border: 1px solid black;\n",
-       "    border-collapse: collapse;\n",
-       "  }\n",
-       "  th, td {\n",
-       "    padding: 5px;\n",
-       "  }\n",
-       "  th {\n",
-       "    text-align: left;\n",
-       "  }\n",
-       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>model</th><th>ds</th><th>unique_id</th><th>predicted</th></tr></thead><tbody><tr><td>Chronos2</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td><td>496_267</td><td>List(33.75, 35.5, 35.5, 36.75, 37.25, 36.75, 37.75)</td></tr><tr><td>ChronosBoltBase</td><td>List(2024-07-03T00:00:00.000Z, 2024-07-04T00:00:00.000Z, 2024-07-05T00:00:00.000Z, 2024-07-06T00:00:00.000Z, 2024-07-07T00:00:00.000Z, 2024-07-08T00:00:00.000Z, 2024-07-09T00:00:00.000Z)</td><td>496_267</td><td>List(30.125, 29.25, 29.125, 30.0, 30.375, 31.0, 30.625)</td></tr><tr><td>TimesFM_2_5_200m</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td><td>496_267</td><td>List(31.817570912397116, 31.92422286904795, 31.16031617875405, 35.18978077201951, 36.086477674362655, 32.43499654390321, 32.33874661988753)</td></tr></tbody></table></div>"
-      ]
-     },
-     "metadata": {
-      "application/vnd.databricks.v1+output": {
-       "addedWidgets": {},
-       "aggData": [],
-       "aggError": "",
-       "aggOverflow": false,
-       "aggSchema": [],
-       "aggSeriesLimitReached": false,
-       "aggType": "",
-       "arguments": {},
-       "columnCustomDisplayInfos": {},
-       "data": [
-        [
-         "Chronos2",
-         [
-          "2024-06-26T00:00:00.000Z",
-          "2024-06-27T00:00:00.000Z",
-          "2024-06-28T00:00:00.000Z",
-          "2024-06-29T00:00:00.000Z",
-          "2024-06-30T00:00:00.000Z",
-          "2024-07-01T00:00:00.000Z",
-          "2024-07-02T00:00:00.000Z"
-         ],
-         "496_267",
-         [
-          33.75,
-          35.5,
-          35.5,
-          36.75,
-          37.25,
-          36.75,
-          37.75
-         ]
-        ],
-        [
-         "ChronosBoltBase",
-         [
-          "2024-07-03T00:00:00.000Z",
-          "2024-07-04T00:00:00.000Z",
-          "2024-07-05T00:00:00.000Z",
-          "2024-07-06T00:00:00.000Z",
-          "2024-07-07T00:00:00.000Z",
-          "2024-07-08T00:00:00.000Z",
-          "2024-07-09T00:00:00.000Z"
-         ],
-         "496_267",
-         [
-          30.125,
-          29.25,
-          29.125,
-          30.0,
-          30.375,
-          31.0,
-          30.625
-         ]
-        ],
-        [
-         "TimesFM_2_5_200m",
-         [
-          "2024-06-26T00:00:00.000Z",
-          "2024-06-27T00:00:00.000Z",
-          "2024-06-28T00:00:00.000Z",
-          "2024-06-29T00:00:00.000Z",
-          "2024-06-30T00:00:00.000Z",
-          "2024-07-01T00:00:00.000Z",
-          "2024-07-02T00:00:00.000Z"
-         ],
-         "496_267",
-         [
-          31.817570912397116,
-          31.92422286904795,
-          31.16031617875405,
-          35.18978077201951,
-          36.086477674362655,
-          32.43499654390321,
-          32.33874661988753
-         ]
-        ]
-       ],
-       "datasetInfos": [
-        {
-         "name": "_sqldf",
-         "schema": {
-          "fields": [
-           {
-            "metadata": {},
-            "name": "model",
-            "nullable": true,
-            "type": "string"
-           },
-           {
-            "metadata": {},
-            "name": "ds",
-            "nullable": true,
-            "type": {
-             "containsNull": true,
-             "elementType": "timestamp",
-             "type": "array"
-            }
-           },
-           {
-            "metadata": {},
-            "name": "unique_id",
-            "nullable": true,
-            "type": "string"
-           },
-           {
-            "metadata": {},
-            "name": "predicted",
-            "nullable": true,
-            "type": {
-             "containsNull": true,
-             "elementType": "double",
-             "type": "array"
-            }
-           }
-          ],
-          "type": "struct"
-         },
-         "tableIdentifier": null,
-         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
-        }
-       ],
-       "dbfsResultPath": null,
-       "isJsonSchema": true,
-       "metadata": {
-        "createTempViewForImplicitDf": true,
-        "dataframeName": "_sqldf",
-        "executionCount": 6
-       },
-       "overflow": false,
-       "plotOptions": {
-        "customPlotOptions": {},
-        "displayType": "table",
-        "pivotAggregation": null,
-        "pivotColumns": null,
-        "xColumns": null,
-        "yColumns": null
-       },
-       "removedWidgets": [],
-       "schema": [
-        {
-         "metadata": "{}",
-         "name": "model",
-         "type": "\"string\""
-        },
-        {
-         "metadata": "{}",
-         "name": "ds",
-         "type": "{\"containsNull\":true,\"elementType\":\"timestamp\",\"type\":\"array\"}"
-        },
-        {
-         "metadata": "{}",
-         "name": "unique_id",
-         "type": "\"string\""
-        },
-        {
-         "metadata": "{}",
-         "name": "predicted",
-         "type": "{\"containsNull\":true,\"elementType\":\"double\",\"type\":\"array\"}"
-        }
-       ],
-       "type": "table"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%sql\n",
     "-- Sample predictions for the top-demand series across all models\n",

--- a/examples/fresh_retail_net/02_fresh_retail_net_mmf_forecast.ipynb
+++ b/examples/fresh_retail_net/02_fresh_retail_net_mmf_forecast.ipynb
@@ -1,0 +1,1389 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "d92364f8-01e2-4090-bea2-f60f202d5cc6",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# FreshRetailNet — Foundation Model Forecasting with MMF (Serverless GPU)\n",
+    "\n",
+    "This notebook runs **foundation time series models** on the FreshRetailNet demand data\n",
+    "using the [Many Model Forecasting (MMF)](https://github.com/databricks-industry-solutions/many-model-forecasting) framework\n",
+    "on **serverless GPU** compute.\n",
+    "\n",
+    "### Prerequisites\n",
+    "- Run the `fresh_retail_net_mmf` notebook first to create `mmf.fresh_retail_net.demand_train` and `mmf.fresh_retail_net.demand_score`\n",
+    "- Attach this notebook to **Serverless** compute with **A10 GPU** accelerator and **Environment version 5+**\n",
+    "\n",
+    "### Foundation Models\n",
+    "We run the following pre-trained foundation models (no training required — zero-shot forecasting):\n",
+    "- **Chronos-Bolt** (Tiny, Mini, Small, Base) — Amazon's efficient time series foundation model\n",
+    "- **Chronos 2** (Base, Small, Synth) — Amazon's next-gen foundation model\n",
+    "- **TimesFM 2.5** — Google's 200M parameter time series foundation model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "caaadf0c-a58f-48c7-868e-e5aca4d7b961",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 1. Install Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207596060,
+     "inputWidgets": {},
+     "nuid": "fb51e6aa-b4b1-457d-8e88-3ac731fb5fa7",
+     "showTitle": false,
+     "startTime": 1781207502554,
+     "submitTime": 1781207502201,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001B[33mWARNING: huggingface-hub 1.19.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.19.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.18.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.18.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.17.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.17.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.16.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.15.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.15.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.14.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.14.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.13.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.13.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.12.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.11.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.11.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.10.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.9.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.8.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.8.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.7.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.6.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.6.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.5.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.5.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.4.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.4.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.4.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.4.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.7 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.7 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.5 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.5 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.3.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.2.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.7 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.7 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.6 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.6 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.5 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.5 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.4 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.3 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.2 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.1.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.0.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.0.1 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.0.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[33mWARNING: huggingface-hub 1.0.0 does not provide the extra 'cli'\u001B[0m\u001B[33m\n\u001B[0m\u001B[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\ndatabricks-serverless-gpu 0.5.11+patch5 requires databricks-connect<16,>=15.4.2, but you have databricks-connect 17.3.8 which is incompatible.\ndatabricks-serverless-gpu 0.5.11+patch5 requires mlflow<3.0,>=2.17, but you have mlflow 3.13.0 which is incompatible.\u001B[0m\u001B[31m\n\u001B[0m\u001B[43mNote: you may need to restart the kernel using %restart_python or dbutils.library.restartPython() to use updated packages.\u001B[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install \"mmf_sa[foundation] @ git+https://github.com/databricks-industry-solutions/many-model-forecasting.git\" hf_transfer --quiet\n",
+    "dbutils.library.restartPython()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "cf13121f-70a4-4376-9166-e473bb4344f9",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 2. Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207611441,
+     "inputWidgets": {},
+     "nuid": "692728a6-98c3-4983-ae06-cf7e89b46ee0",
+     "showTitle": false,
+     "startTime": 1781207596186,
+     "submitTime": 1781207502216,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train rows: 90,000  |  Score rows: 7,000\n"
+     ]
+    }
+   ],
+   "source": [
+    "import logging\n",
+    "import uuid\n",
+    "\n",
+    "# Suppress noisy loggers on serverless\n",
+    "logging.getLogger(\"mlflow.tracking.context.registry\").setLevel(logging.ERROR)\n",
+    "logging.getLogger(\"py4j.clientserver\").setLevel(logging.WARNING)\n",
+    "logging.getLogger(\"py4j.java_gateway\").setLevel(logging.WARNING)\n",
+    "\n",
+    "catalog = \"mmf\"\n",
+    "db = \"fresh_retail_net\"\n",
+    "user = spark.sql(\"SELECT current_user() AS user\").collect()[0][\"user\"]\n",
+    "\n",
+    "# Verify tables exist\n",
+    "train_count = spark.table(f\"{catalog}.{db}.demand_train\").count()\n",
+    "score_count = spark.table(f\"{catalog}.{db}.demand_score\").count()\n",
+    "print(f\"Train rows: {train_count:,}  |  Score rows: {score_count:,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "ea36b960-4b14-47a9-ae56-d8e93a3b013e",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 3. Define Foundation Models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207611542,
+     "inputWidgets": {},
+     "nuid": "8e04db26-c652-4208-b78f-f2fd83030d8a",
+     "showTitle": false,
+     "startTime": 1781207611461,
+     "submitTime": 1781207502229,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Models to run: 3\n  - ChronosBoltBase\n  - Chronos2\n  - TimesFM_2_5_200m\n"
+     ]
+    }
+   ],
+   "source": [
+    "active_models = [\n",
+    "    \"ChronosBoltBase\",\n",
+    "    \"Chronos2\",\n",
+    "    \"TimesFM_2_5_200m\",\n",
+    "]\n",
+    "\n",
+    "print(f\"Models to run: {len(active_models)}\")\n",
+    "for m in active_models:\n",
+    "    print(f\"  - {m}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "b825ceb0-e741-4605-aa8c-c4c78779ed55",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 4. Run Foundation Model Forecasts\n",
+    "\n",
+    "On serverless GPU, we run **one model at a time** in a loop because Spark Connect Python workers\n",
+    "are CPU-only even when the driver has a GPU. The `serverless=True` flag enables driver-only\n",
+    "prediction path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207907427,
+     "inputWidgets": {},
+     "nuid": "1c7753fa-b81d-47f2-b8e6-c4bce8d6f0b9",
+     "showTitle": false,
+     "startTime": 1781207611553,
+     "submitTime": 1781207502245,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n============================================================\nRunning ChronosBoltBase (run_id=772b28cf-b3e3-4001-93ec-3b7ce17db099)\n============================================================\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026/06/11 19:53:35 INFO mlflow.tracking.fluent: Experiment with name '/Users/visvenky@amazon.com/mmf/fresh_retail_net' does not exist. Creating a new experiment.\n\u001B[1;38;5;208mIf you are using MLflow Tracing, consider storing your traces in Unity Catalog for unlimited storage (no 100,000 trace limit), fine-grained access controls, and queryability from notebooks, SQL, and dashboards. \u001B[94mLearn more: https://docs.databricks.com/aws/en/mlflow3/genai/tracing/trace-unity-catalog\u001B[0m\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Run quality checks\nFinished quality checks\nStarting evaluate_score\nStarting evaluate_models\nStarted evaluating ChronosBoltBase\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/system_metrics/metrics/gpu_monitor.py:11: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.\n  import pynvml\n2026/06/11 19:53:39 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:156: FutureWarning: Model's `predict` method contains invalid parameters: {'input_data'}. Only the following parameter names are allowed: context, model_input, and params. Note that invalid parameters will no longer be permitted in future versions.\n  param_names = _check_func_signature(func, \"predict\")\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:187: UserWarning: \u001B[33mAdd type hints to the `predict` method to enable data validation and automatic signature inference during model logging. Check https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel for more details.\u001B[0m\n  color_warning(\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:156: FutureWarning: Model's `predict` method contains invalid parameters: {'input_data'}. Only the following parameter names are allowed: context, model_input, and params. Note that invalid parameters will no longer be permitted in future versions.\n  param_names = _check_func_signature(func, \"predict\")\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:187: UserWarning: \u001B[33mAdd type hints to the `predict` method to enable data validation and automatic signature inference during model logging. Check https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel for more details.\u001B[0m\n  color_warning(\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aff5b8441c0a4270adb3206a3f3e321e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2e509747d9034a3d818d13b5d0b81d2a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors:   0%|          | 0.00/821M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026/06/11 19:54:07 WARNING mlflow.models.model: `artifact_path` is deprecated. Please use `name` instead.\n\uD83D\uDD17 View Logged Model at: https://aws-daisdemo.cloud.databricks.com/ml/experiments/3276803282238396/models/m-2e58f1d038cb4267a2fea50851bb2897?o=7474649743221542\n2026/06/11 19:54:10 INFO mlflow.pyfunc: Validating input example against model signature\nSuccessfully registered model 'mmf.fresh_retail_net.chronosboltbase_fresh_retail_net'.\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "287e065498004f3baeb6b4e3c1b88dc0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Uploading artifacts:   0%|          | 0/11 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\uD83D\uDD17 Created version '1' of model 'mmf.fresh_retail_net.chronosboltbase_fresh_retail_net': https://aws-daisdemo.cloud.databricks.com/explore/data/models/mmf/fresh_retail_net/chronosboltbase_fresh_retail_net/version/1?o=7474649743221542\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  metric_name  metric_value\n0       smape       0.46902\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026/06/11 19:55:15 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n2026/06/11 19:55:16 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished evaluating ChronosBoltBase\nFinished evaluate_models\nStarting run_scoring\nStarted scoring with ChronosBoltBase\nRunning scoring for ChronosBoltBase...\nFinished scoring with ChronosBoltBase\nFinished run_scoring\nFinished evaluate_score\n\n============================================================\nRunning Chronos2 (run_id=772b28cf-b3e3-4001-93ec-3b7ce17db099)\n============================================================\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001B[1;38;5;208mIf you are using MLflow Tracing, you can migrate your traces to Unity Catalog for unlimited storage, fine-grained access controls, and queryability from notebooks, SQL, and dashboards. \u001B[94mLearn more: https://docs.databricks.com/aws/en/mlflow3/genai/tracing/migrate-traces-to-uc\u001B[0m\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Run quality checks\nFinished quality checks\nStarting evaluate_score\nStarting evaluate_models\nStarted evaluating Chronos2\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026/06/11 19:55:36 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9d6176fc66d44b35b3bf7bbb32bfb217",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "709b6da2ac6f4dc6a2b4f1a4169b72b9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors:   0%|          | 0.00/478M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026/06/11 19:55:42 WARNING mlflow.models.model: `artifact_path` is deprecated. Please use `name` instead.\n\uD83D\uDD17 View Logged Model at: https://aws-daisdemo.cloud.databricks.com/ml/experiments/3276803282238396/models/m-6084f8769dac4ddfa565272c398c8124?o=7474649743221542\n2026/06/11 19:55:42 INFO mlflow.pyfunc: Validating input example against model signature\nSuccessfully registered model 'mmf.fresh_retail_net.chronos2_fresh_retail_net'.\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "360245535ea843b1bbddc8abaa869a52",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Uploading artifacts:   0%|          | 0/11 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\uD83D\uDD17 Created version '1' of model 'mmf.fresh_retail_net.chronos2_fresh_retail_net': https://aws-daisdemo.cloud.databricks.com/explore/data/models/mmf/fresh_retail_net/chronos2_fresh_retail_net/version/1?o=7474649743221542\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  metric_name  metric_value\n0       smape      0.471685\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026/06/11 19:56:57 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n2026/06/11 19:56:57 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished evaluating Chronos2\nFinished evaluate_models\nStarting run_scoring\nStarted scoring with Chronos2\nRunning scoring for Chronos2...\nFinished scoring with Chronos2\nFinished run_scoring\nFinished evaluate_score\n\n============================================================\nRunning TimesFM_2_5_200m (run_id=772b28cf-b3e3-4001-93ec-3b7ce17db099)\n============================================================\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001B[1;38;5;208mIf you are using MLflow Tracing, you can migrate your traces to Unity Catalog for unlimited storage, fine-grained access controls, and queryability from notebooks, SQL, and dashboards. \u001B[94mLearn more: https://docs.databricks.com/aws/en/mlflow3/genai/tracing/migrate-traces-to-uc\u001B[0m\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Run quality checks\nFinished quality checks\nStarting evaluate_score\nStarting evaluate_models\nStarted evaluating TimesFM_2_5_200m\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026/06/11 19:57:33 INFO mlflow.system_metrics.system_metrics_monitor: Started monitoring system metrics.\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:156: FutureWarning: Model's `predict` method contains invalid parameters: {'input_data'}. Only the following parameter names are allowed: context, model_input, and params. Note that invalid parameters will no longer be permitted in future versions.\n  param_names = _check_func_signature(func, \"predict\")\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/utils/data_validation.py:187: UserWarning: \u001B[33mAdd type hints to the `predict` method to enable data validation and automatic signature inference during model logging. Check https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel for more details.\u001B[0m\n  color_warning(\n2026/06/11 19:57:35 WARNING mlflow.models.model: `artifact_path` is deprecated. Please use `name` instead.\n\uD83D\uDD17 View Logged Model at: https://aws-daisdemo.cloud.databricks.com/ml/experiments/3276803282238396/models/m-ec85d6d898814975ad8bf3c1513ad6f2?o=7474649743221542\n/local_disk0/.ephemeral_nfs/envs/pythonEnv-65577a83-829a-4632-bebf-1e3fb1d74cff/lib/python3.12/site-packages/mlflow/pyfunc/__init__.py:3341: UserWarning: \u001B[1;33mAn input example was not provided when logging the model. To ensure the model signature functions correctly, specify the `input_example` parameter. See https://mlflow.org/docs/latest/model/signatures.html#model-input-example for more details about the benefits of using input_example.\u001B[0m\n  color_warning(\nSuccessfully registered model 'mmf.fresh_retail_net.timesfm_2_5_200m_fresh_retail_net'.\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9e8d90b2d6f54e97a3dad225d34bb80f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Uploading artifacts:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\uD83D\uDD17 Created version '1' of model 'mmf.fresh_retail_net.timesfm_2_5_200m_fresh_retail_net': https://aws-daisdemo.cloud.databricks.com/explore/data/models/mmf/fresh_retail_net/timesfm_2_5_200m_fresh_retail_net/version/1?o=7474649743221542\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b432bd332dd14d92988633acadb44077",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json:   0%|          | 0.00/475 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "58c4d6ad9d9a4fdc9deb4eeb6b274fe8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json:   0%|          | 0.00/475 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloaded.\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d11830e828c44d96bbfa885d29ca0347",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors:   0%|          | 0.00/925M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  metric_name  metric_value\n0       smape      0.453783\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026/06/11 19:58:12 INFO mlflow.system_metrics.system_metrics_monitor: Stopping system metrics monitoring...\n2026/06/11 19:58:12 INFO mlflow.system_metrics.system_metrics_monitor: Successfully terminated system metrics monitoring!\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished evaluating TimesFM_2_5_200m\nFinished evaluate_models\nStarting run_scoring\nStarted scoring with TimesFM_2_5_200m\nRunning scoring for TimesFM_2_5_200m...\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:mmf_sa.data_quality_checks:External regressors detected, checking resampling configuration\nINFO:mmf_sa.data_quality_checks:External regressors configuration validation passed\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3e9eb1a4ae2b450daaec32ebe796e75e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json:   0%|          | 0.00/475 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloaded.\nFinished scoring with TimesFM_2_5_200m\nFinished run_scoring\nFinished evaluate_score\n"
+     ]
+    }
+   ],
+   "source": [
+    "from mmf_sa import run_forecast\n",
+    "\n",
+    "run_id = str(uuid.uuid4())\n",
+    "prediction_length = 7  # 7-day forecast horizon (matches eval split)\n",
+    "\n",
+    "for model in active_models:\n",
+    "    print(f\"\\n{'='*60}\")\n",
+    "    print(f\"Running {model} (run_id={run_id})\")\n",
+    "    print(f\"{'='*60}\")\n",
+    "    run_forecast(\n",
+    "        spark=spark,\n",
+    "        train_data=f\"{catalog}.{db}.demand_train\",\n",
+    "        scoring_data=f\"{catalog}.{db}.demand_score\",\n",
+    "        scoring_output=f\"{catalog}.{db}.scoring_output\",\n",
+    "        evaluation_output=f\"{catalog}.{db}.evaluation_output\",\n",
+    "        model_output=f\"{catalog}.{db}\",\n",
+    "        group_id=\"unique_id\",\n",
+    "        date_col=\"ds\",\n",
+    "        target=\"y\",\n",
+    "        freq=\"D\",\n",
+    "        prediction_length=prediction_length,\n",
+    "        backtest_length=21,\n",
+    "        stride=7,\n",
+    "        metric=\"smape\",\n",
+    "        train_predict_ratio=2,\n",
+    "        data_quality_check=False,\n",
+    "        resample=False,\n",
+    "        active_models=[model],\n",
+    "        dynamic_future_numerical = [\"discount\", \"precpt\", \"avg_temperature\", \"avg_humidity\", \"avg_wind_level\"], \n",
+    "        dynamic_future_categorical =[\"holiday_flag\", \"activity_flag\"],\n",
+    "        experiment_path=f\"/Users/{user}/mmf/fresh_retail_net\",\n",
+    "        use_case_name=\"fresh_retail_net\",\n",
+    "        run_id=run_id,\n",
+    "        accelerator=\"gpu\",\n",
+    "        serverless=True,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "ed0f1103-a656-4916-8902-2ee8cabb208b",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 5. Review Evaluation Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207909635,
+     "inputWidgets": {},
+     "nuid": "9fd789a9-aad1-4c05-9ec1-7736bdfcbec0",
+     "showTitle": false,
+     "startTime": 1781207907470,
+     "submitTime": 1781207502259,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>model</th><th>num_series</th><th>avg_smape</th><th>median_smape</th></tr></thead><tbody><tr><td>TimesFM_2_5_200m</td><td>1000</td><td>0.4538</td><td>0.3812</td></tr><tr><td>ChronosBoltBase</td><td>1000</td><td>0.469</td><td>0.394</td></tr><tr><td>Chronos2</td><td>1000</td><td>0.4717</td><td>0.3988</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         "TimesFM_2_5_200m",
+         1000,
+         0.4538,
+         0.3812
+        ],
+        [
+         "ChronosBoltBase",
+         1000,
+         0.469,
+         0.394
+        ],
+        [
+         "Chronos2",
+         1000,
+         0.4717,
+         0.3988
+        ]
+       ],
+       "datasetInfos": [
+        {
+         "name": "_sqldf",
+         "schema": {
+          "fields": [
+           {
+            "metadata": {},
+            "name": "model",
+            "nullable": true,
+            "type": "string"
+           },
+           {
+            "metadata": {},
+            "name": "num_series",
+            "nullable": false,
+            "type": "long"
+           },
+           {
+            "metadata": {},
+            "name": "avg_smape",
+            "nullable": true,
+            "type": "double"
+           },
+           {
+            "metadata": {},
+            "name": "median_smape",
+            "nullable": true,
+            "type": "double"
+           }
+          ],
+          "type": "struct"
+         },
+         "tableIdentifier": null,
+         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
+        }
+       ],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {
+        "createTempViewForImplicitDf": true,
+        "dataframeName": "_sqldf",
+        "executionCount": 4
+       },
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "model",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "num_series",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "avg_smape",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "median_smape",
+         "type": "\"double\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%sql\n",
+    "SELECT\n",
+    "  model,\n",
+    "  COUNT(DISTINCT unique_id) AS num_series,\n",
+    "  ROUND(AVG(metric_value), 4) AS avg_smape,\n",
+    "  ROUND(PERCENTILE(metric_value, 0.5), 4) AS median_smape\n",
+    "FROM mmf.fresh_retail_net.evaluation_output\n",
+    "GROUP BY model\n",
+    "ORDER BY avg_smape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "fef5f78f-423c-4302-b2c7-c4b199198f23",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 6. Review Scoring Output (Future Predictions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207911130,
+     "inputWidgets": {},
+     "nuid": "48b74cab-2d3b-4e05-b896-57d7cdac8598",
+     "showTitle": false,
+     "startTime": 1781207909695,
+     "submitTime": 1781207502275,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>model</th><th>num_series</th><th>total_predictions</th><th>min_date</th><th>max_date</th></tr></thead><tbody><tr><td>Chronos2</td><td>1000</td><td>1000</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td></tr><tr><td>ChronosBoltBase</td><td>1000</td><td>1000</td><td>List(2024-07-03T00:00:00.000Z, 2024-07-04T00:00:00.000Z, 2024-07-05T00:00:00.000Z, 2024-07-06T00:00:00.000Z, 2024-07-07T00:00:00.000Z, 2024-07-08T00:00:00.000Z, 2024-07-09T00:00:00.000Z)</td><td>List(2024-07-03T00:00:00.000Z, 2024-07-04T00:00:00.000Z, 2024-07-05T00:00:00.000Z, 2024-07-06T00:00:00.000Z, 2024-07-07T00:00:00.000Z, 2024-07-08T00:00:00.000Z, 2024-07-09T00:00:00.000Z)</td></tr><tr><td>TimesFM_2_5_200m</td><td>1000</td><td>1000</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         "Chronos2",
+         1000,
+         1000,
+         [
+          "2024-06-26T00:00:00.000Z",
+          "2024-06-27T00:00:00.000Z",
+          "2024-06-28T00:00:00.000Z",
+          "2024-06-29T00:00:00.000Z",
+          "2024-06-30T00:00:00.000Z",
+          "2024-07-01T00:00:00.000Z",
+          "2024-07-02T00:00:00.000Z"
+         ],
+         [
+          "2024-06-26T00:00:00.000Z",
+          "2024-06-27T00:00:00.000Z",
+          "2024-06-28T00:00:00.000Z",
+          "2024-06-29T00:00:00.000Z",
+          "2024-06-30T00:00:00.000Z",
+          "2024-07-01T00:00:00.000Z",
+          "2024-07-02T00:00:00.000Z"
+         ]
+        ],
+        [
+         "ChronosBoltBase",
+         1000,
+         1000,
+         [
+          "2024-07-03T00:00:00.000Z",
+          "2024-07-04T00:00:00.000Z",
+          "2024-07-05T00:00:00.000Z",
+          "2024-07-06T00:00:00.000Z",
+          "2024-07-07T00:00:00.000Z",
+          "2024-07-08T00:00:00.000Z",
+          "2024-07-09T00:00:00.000Z"
+         ],
+         [
+          "2024-07-03T00:00:00.000Z",
+          "2024-07-04T00:00:00.000Z",
+          "2024-07-05T00:00:00.000Z",
+          "2024-07-06T00:00:00.000Z",
+          "2024-07-07T00:00:00.000Z",
+          "2024-07-08T00:00:00.000Z",
+          "2024-07-09T00:00:00.000Z"
+         ]
+        ],
+        [
+         "TimesFM_2_5_200m",
+         1000,
+         1000,
+         [
+          "2024-06-26T00:00:00.000Z",
+          "2024-06-27T00:00:00.000Z",
+          "2024-06-28T00:00:00.000Z",
+          "2024-06-29T00:00:00.000Z",
+          "2024-06-30T00:00:00.000Z",
+          "2024-07-01T00:00:00.000Z",
+          "2024-07-02T00:00:00.000Z"
+         ],
+         [
+          "2024-06-26T00:00:00.000Z",
+          "2024-06-27T00:00:00.000Z",
+          "2024-06-28T00:00:00.000Z",
+          "2024-06-29T00:00:00.000Z",
+          "2024-06-30T00:00:00.000Z",
+          "2024-07-01T00:00:00.000Z",
+          "2024-07-02T00:00:00.000Z"
+         ]
+        ]
+       ],
+       "datasetInfos": [
+        {
+         "name": "_sqldf",
+         "schema": {
+          "fields": [
+           {
+            "metadata": {},
+            "name": "model",
+            "nullable": true,
+            "type": "string"
+           },
+           {
+            "metadata": {},
+            "name": "num_series",
+            "nullable": false,
+            "type": "long"
+           },
+           {
+            "metadata": {},
+            "name": "total_predictions",
+            "nullable": false,
+            "type": "long"
+           },
+           {
+            "metadata": {},
+            "name": "min_date",
+            "nullable": true,
+            "type": {
+             "containsNull": true,
+             "elementType": "timestamp",
+             "type": "array"
+            }
+           },
+           {
+            "metadata": {},
+            "name": "max_date",
+            "nullable": true,
+            "type": {
+             "containsNull": true,
+             "elementType": "timestamp",
+             "type": "array"
+            }
+           }
+          ],
+          "type": "struct"
+         },
+         "tableIdentifier": null,
+         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
+        }
+       ],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {
+        "createTempViewForImplicitDf": true,
+        "dataframeName": "_sqldf",
+        "executionCount": 5
+       },
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "model",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "num_series",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "total_predictions",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "min_date",
+         "type": "{\"containsNull\":true,\"elementType\":\"timestamp\",\"type\":\"array\"}"
+        },
+        {
+         "metadata": "{}",
+         "name": "max_date",
+         "type": "{\"containsNull\":true,\"elementType\":\"timestamp\",\"type\":\"array\"}"
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%sql\n",
+    "SELECT\n",
+    "  model,\n",
+    "  COUNT(DISTINCT unique_id) AS num_series,\n",
+    "  COUNT(*) AS total_predictions,\n",
+    "  MIN(ds) AS min_date,\n",
+    "  MAX(ds) AS max_date\n",
+    "FROM mmf.fresh_retail_net.scoring_output\n",
+    "GROUP BY model\n",
+    "ORDER BY model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "implicitDf": true,
+      "rowLimit": 10000
+     },
+     "finishTime": 1781207912932,
+     "inputWidgets": {},
+     "nuid": "f457ee17-619a-4f8c-8483-78f71b32b2dd",
+     "showTitle": false,
+     "startTime": 1781207911141,
+     "submitTime": 1781207502277,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>model</th><th>ds</th><th>unique_id</th><th>predicted</th></tr></thead><tbody><tr><td>Chronos2</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td><td>496_267</td><td>List(33.75, 35.5, 35.5, 36.75, 37.25, 36.75, 37.75)</td></tr><tr><td>ChronosBoltBase</td><td>List(2024-07-03T00:00:00.000Z, 2024-07-04T00:00:00.000Z, 2024-07-05T00:00:00.000Z, 2024-07-06T00:00:00.000Z, 2024-07-07T00:00:00.000Z, 2024-07-08T00:00:00.000Z, 2024-07-09T00:00:00.000Z)</td><td>496_267</td><td>List(30.125, 29.25, 29.125, 30.0, 30.375, 31.0, 30.625)</td></tr><tr><td>TimesFM_2_5_200m</td><td>List(2024-06-26T00:00:00.000Z, 2024-06-27T00:00:00.000Z, 2024-06-28T00:00:00.000Z, 2024-06-29T00:00:00.000Z, 2024-06-30T00:00:00.000Z, 2024-07-01T00:00:00.000Z, 2024-07-02T00:00:00.000Z)</td><td>496_267</td><td>List(31.817570912397116, 31.92422286904795, 31.16031617875405, 35.18978077201951, 36.086477674362655, 32.43499654390321, 32.33874661988753)</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         "Chronos2",
+         [
+          "2024-06-26T00:00:00.000Z",
+          "2024-06-27T00:00:00.000Z",
+          "2024-06-28T00:00:00.000Z",
+          "2024-06-29T00:00:00.000Z",
+          "2024-06-30T00:00:00.000Z",
+          "2024-07-01T00:00:00.000Z",
+          "2024-07-02T00:00:00.000Z"
+         ],
+         "496_267",
+         [
+          33.75,
+          35.5,
+          35.5,
+          36.75,
+          37.25,
+          36.75,
+          37.75
+         ]
+        ],
+        [
+         "ChronosBoltBase",
+         [
+          "2024-07-03T00:00:00.000Z",
+          "2024-07-04T00:00:00.000Z",
+          "2024-07-05T00:00:00.000Z",
+          "2024-07-06T00:00:00.000Z",
+          "2024-07-07T00:00:00.000Z",
+          "2024-07-08T00:00:00.000Z",
+          "2024-07-09T00:00:00.000Z"
+         ],
+         "496_267",
+         [
+          30.125,
+          29.25,
+          29.125,
+          30.0,
+          30.375,
+          31.0,
+          30.625
+         ]
+        ],
+        [
+         "TimesFM_2_5_200m",
+         [
+          "2024-06-26T00:00:00.000Z",
+          "2024-06-27T00:00:00.000Z",
+          "2024-06-28T00:00:00.000Z",
+          "2024-06-29T00:00:00.000Z",
+          "2024-06-30T00:00:00.000Z",
+          "2024-07-01T00:00:00.000Z",
+          "2024-07-02T00:00:00.000Z"
+         ],
+         "496_267",
+         [
+          31.817570912397116,
+          31.92422286904795,
+          31.16031617875405,
+          35.18978077201951,
+          36.086477674362655,
+          32.43499654390321,
+          32.33874661988753
+         ]
+        ]
+       ],
+       "datasetInfos": [
+        {
+         "name": "_sqldf",
+         "schema": {
+          "fields": [
+           {
+            "metadata": {},
+            "name": "model",
+            "nullable": true,
+            "type": "string"
+           },
+           {
+            "metadata": {},
+            "name": "ds",
+            "nullable": true,
+            "type": {
+             "containsNull": true,
+             "elementType": "timestamp",
+             "type": "array"
+            }
+           },
+           {
+            "metadata": {},
+            "name": "unique_id",
+            "nullable": true,
+            "type": "string"
+           },
+           {
+            "metadata": {},
+            "name": "predicted",
+            "nullable": true,
+            "type": {
+             "containsNull": true,
+             "elementType": "double",
+             "type": "array"
+            }
+           }
+          ],
+          "type": "struct"
+         },
+         "tableIdentifier": null,
+         "typeStr": "pyspark.sql.connect.dataframe.DataFrame"
+        }
+       ],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {
+        "createTempViewForImplicitDf": true,
+        "dataframeName": "_sqldf",
+        "executionCount": 6
+       },
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "model",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "ds",
+         "type": "{\"containsNull\":true,\"elementType\":\"timestamp\",\"type\":\"array\"}"
+        },
+        {
+         "metadata": "{}",
+         "name": "unique_id",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "predicted",
+         "type": "{\"containsNull\":true,\"elementType\":\"double\",\"type\":\"array\"}"
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%sql\n",
+    "-- Sample predictions for the top-demand series across all models\n",
+    "WITH top_series AS (\n",
+    "  SELECT unique_id\n",
+    "  FROM mmf.fresh_retail_net.demand_train\n",
+    "  GROUP BY unique_id\n",
+    "  ORDER BY SUM(y) DESC\n",
+    "  LIMIT 1\n",
+    ")\n",
+    "SELECT s.model, s.ds, s.unique_id, s.y AS predicted\n",
+    "FROM mmf.fresh_retail_net.scoring_output s\n",
+    "JOIN top_series t ON s.unique_id = t.unique_id\n",
+    "ORDER BY s.model, s.ds"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": {
+    "hardware": {
+     "accelerator": "A10",
+     "gpuPoolId": null,
+     "memory": null
+    },
+    "software": {
+     "pinSparkToX86": null
+    }
+   },
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "4"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "experimentId": "3276803282238396",
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": 8071543352362869,
+     "dataframes": [
+      "_sqldf"
+     ]
+    },
+    "pythonIndentUnit": 2
+   },
+   "notebookName": "fresh_retail_net_mmf_forecast",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/fresh_retail_net/03_build_product_location_dims.ipynb
+++ b/examples/fresh_retail_net/03_build_product_location_dims.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Build Illustrative Product & Location Dimension Tables\n\nFreshRetailNet anonymizes everything to integers (`product_id`, `city_id`, integer category IDs) — no\nproduct names, no regions. The blog narrative needs friendly labels (\"Skim Milk\", \"Northeast\") so business\nusers can ask natural questions and so orders name a real product.\n\nThis notebook creates two **synthetic, illustrative** dimension tables, keyed to the **real**\n`product_id` / `city_id` values, so they join cleanly to the forecast and supplier data:\n\n- `mmf.fresh_retail_net.product_dim`  — product_id → product_name, category, subcategory, brand, base_price\n- `mmf.fresh_retail_net.location_dim` — city_id → city_name, region, state, store_type\n\n> **Data boundary (important):** Schema/field *style* was informed by looking at a public synthetic-retail\n> example (a Kaggle CSV) during development. **No external dataset is read, loaded, joined, or shipped by\n> this notebook** — every value below is generated here from hardcoded grocery vocabularies. The Kaggle file\n> is a local design reference for this conversation only and is NOT a dependency or part of any distribution.\n\n**Provenance / honesty:** the names are **fully synthetic and illustrative**. They are NOT from\nFreshRetailNet (which has no names), and NOT copied from M5/M4. All values are generated here and use\ngrocery-appropriate names to match the perishable-grocery nature of FreshRetailNet.\nThe blog must state: *product and region names are illustrative labels applied to the dataset's anonymized identifiers.*\n\n**Hero mapping:** surge SKU `18_122` (product 122, city 0) is deliberately labeled **\"Skim Milk\" / \"Northeast\"**\nso the blog's flagship question lands on a SKU that genuinely shows a forecast spike.\n\nDeterministic (no RNG) — reproducible."
+   "source": [
+    "# Build Illustrative Product & Location Dimension Tables\n",
+    "\n",
+    "FreshRetailNet anonymizes everything to integers (`product_id`, `city_id`, integer category IDs) \u2014 no ",
+    "product names, no regions. To let business users ask natural-language questions over the forecast ",
+    "(and to have orders name a real product), this notebook maps those IDs to friendly labels ",
+    "(\"Skim Milk\", \"Northeast\").\n",
+    "\n",
+    "These dimension tables are **synthetic and illustrative only** \u2014 they are not real data from any customer.\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -77,7 +86,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. product_dim — deterministic synthetic names keyed to real product_id"
+    "## 2. product_dim \u2014 deterministic synthetic names keyed to real product_id"
    ]
   },
   {
@@ -125,7 +134,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. location_dim — deterministic synthetic city/region keyed to real city_id"
+    "## 3. location_dim \u2014 deterministic synthetic city/region keyed to real city_id"
    ]
   },
   {
@@ -188,7 +197,7 @@
     "## 5. Next steps\n",
     "\n",
     "Add `product_dim` and `location_dim` to the **Fresh Retail Sales Forecasting** Genie space, and extend the\n",
-    "Genie instructions so it maps names → ids:\n",
+    "Genie instructions so it maps names \u2192 ids:\n",
     "\n",
     "> A SKU's product name comes from `product_dim` (join on product_id); its region/city from `location_dim`\n",
     "> (join on city_id). When a user names a product (e.g. \"Skim Milk\") or region (e.g. \"Northeast\"), resolve\n",

--- a/examples/fresh_retail_net/03_build_product_location_dims.ipynb
+++ b/examples/fresh_retail_net/03_build_product_location_dims.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Build Illustrative Product & Location Dimension Tables\n\nFreshRetailNet anonymizes everything to integers (`product_id`, `city_id`, integer category IDs) — no\nproduct names, no regions. The blog narrative needs friendly labels (\"Skim Milk\", \"Northeast\") so business\nusers can ask natural questions and so orders name a real product.\n\nThis notebook creates two **synthetic, illustrative** dimension tables, keyed to the **real**\n`product_id` / `city_id` values, so they join cleanly to the forecast and supplier data:\n\n- `mmf.fresh_retail_net.product_dim`  — product_id → product_name, category, subcategory, brand, base_price\n- `mmf.fresh_retail_net.location_dim` — city_id → city_name, region, state, store_type\n\n> **Data boundary (important):** Schema/field *style* was informed by looking at a public synthetic-retail\n> example (a Kaggle CSV) during development. **No external dataset is read, loaded, joined, or shipped by\n> this notebook** — every value below is generated here from hardcoded grocery vocabularies. The Kaggle file\n> is a local design reference for this conversation only and is NOT a dependency or part of any distribution.\n\n**Provenance / honesty:** the names are **fully synthetic and illustrative**. They are NOT from\nFreshRetailNet (which has no names), and NOT copied from M5/M4. All values are generated here and use\ngrocery-appropriate names to match the perishable-grocery nature of FreshRetailNet.\nThe blog must state: *product and region names are illustrative labels applied to the dataset's anonymized identifiers.*\n\n**Hero mapping:** surge SKU `18_122` (product 122, city 0) is deliberately labeled **\"Skim Milk\" / \"Northeast\"**\nso the blog's flagship question lands on a SKU that genuinely shows a forecast spike.\n\nDeterministic (no RNG) — reproducible."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration & vocabularies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CATALOG, SCHEMA = \"mmf\", \"fresh_retail_net\"\n",
+    "SRC = f\"{CATALOG}.{SCHEMA}.demand_train\"   # real product_id / city_id live here\n",
+    "\n",
+    "# Grocery vocabulary (illustrative). Structure styled after a public synthetic retail dataset\n",
+    "# (category/subcategory/brand/region/store_type), values are grocery to fit FreshRetailNet + the\n",
+    "# 'Skim Milk' narrative.\n",
+    "CATEGORIES = {\n",
+    "    \"Dairy\":      [\"Fresh Milk\", \"Yogurt\", \"Cheese\", \"Butter & Spreads\"],\n",
+    "    \"Produce\":    [\"Leafy Greens\", \"Fresh Fruit\", \"Root Vegetables\", \"Herbs\"],\n",
+    "    \"Bakery\":     [\"Bread\", \"Pastries\", \"Tortillas\"],\n",
+    "    \"Meat & Seafood\": [\"Poultry\", \"Beef\", \"Pork\", \"Seafood\"],\n",
+    "    \"Beverages\":  [\"Juice\", \"Bottled Water\", \"Soft Drinks\", \"Cold Brew\"],\n",
+    "    \"Frozen\":     [\"Frozen Meals\", \"Ice Cream\", \"Frozen Vegetables\"],\n",
+    "    \"Pantry\":     [\"Cereal\", \"Pasta & Rice\", \"Canned Goods\", \"Snacks\"],\n",
+    "}\n",
+    "PRODUCT_WORDS = {\n",
+    "    \"Fresh Milk\": [\"Skim Milk\", \"Whole Milk\", \"2% Milk\", \"Oat Milk\", \"Almond Milk\"],\n",
+    "    \"Yogurt\": [\"Greek Yogurt\", \"Vanilla Yogurt\", \"Strawberry Yogurt\"],\n",
+    "    \"Leafy Greens\": [\"Baby Spinach\", \"Romaine Lettuce\", \"Kale\"],\n",
+    "    \"Fresh Fruit\": [\"Bananas\", \"Strawberries\", \"Blueberries\", \"Avocados\"],\n",
+    "    \"Bread\": [\"Whole Wheat Bread\", \"Sourdough Loaf\", \"Multigrain Bread\"],\n",
+    "    \"Poultry\": [\"Chicken Breast\", \"Ground Turkey\"],\n",
+    "    \"Juice\": [\"Orange Juice\", \"Apple Juice\"],\n",
+    "    \"Ice Cream\": [\"Vanilla Ice Cream\", \"Chocolate Ice Cream\"],\n",
+    "    \"Cereal\": [\"Granola\", \"Corn Flakes\", \"Oat Cereal\"],\n",
+    "}\n",
+    "BRANDS = [\"FreshCo\", \"DailyHarvest\", \"GreenLeaf\", \"PureValley\", \"MarketBasket\", \"Orchard&Co\"]\n",
+    "\n",
+    "# Regions / cities (illustrative US). 18 cities -> spread across regions.\n",
+    "REGIONS = [\"Northeast\", \"Southeast\", \"Midwest\", \"Southwest\", \"West\", \"Northwest\"]\n",
+    "CITY_NAMES = [\"Boston\", \"New York\", \"Philadelphia\", \"Atlanta\", \"Miami\", \"Charlotte\",\n",
+    "              \"Chicago\", \"Detroit\", \"Minneapolis\", \"Dallas\", \"Houston\", \"Phoenix\",\n",
+    "              \"Los Angeles\", \"San Francisco\", \"Seattle\", \"Portland\", \"Denver\", \"Las Vegas\"]\n",
+    "REGION_OF_CITY = {  # keep city->region geographically sensible\n",
+    "    \"Boston\": \"Northeast\", \"New York\": \"Northeast\", \"Philadelphia\": \"Northeast\",\n",
+    "    \"Atlanta\": \"Southeast\", \"Miami\": \"Southeast\", \"Charlotte\": \"Southeast\",\n",
+    "    \"Chicago\": \"Midwest\", \"Detroit\": \"Midwest\", \"Minneapolis\": \"Midwest\",\n",
+    "    \"Dallas\": \"Southwest\", \"Houston\": \"Southwest\", \"Phoenix\": \"Southwest\",\n",
+    "    \"Los Angeles\": \"West\", \"San Francisco\": \"West\", \"Las Vegas\": \"West\",\n",
+    "    \"Seattle\": \"Northwest\", \"Portland\": \"Northwest\", \"Denver\": \"West\",\n",
+    "}\n",
+    "STATE_OF_CITY = {\n",
+    "    \"Boston\": \"MA\", \"New York\": \"NY\", \"Philadelphia\": \"PA\", \"Atlanta\": \"GA\", \"Miami\": \"FL\",\n",
+    "    \"Charlotte\": \"NC\", \"Chicago\": \"IL\", \"Detroit\": \"MI\", \"Minneapolis\": \"MN\", \"Dallas\": \"TX\",\n",
+    "    \"Houston\": \"TX\", \"Phoenix\": \"AZ\", \"Los Angeles\": \"CA\", \"San Francisco\": \"CA\",\n",
+    "    \"Seattle\": \"WA\", \"Portland\": \"OR\", \"Denver\": \"CO\", \"Las Vegas\": \"NV\",\n",
+    "}\n",
+    "STORE_TYPES = [\"Hypermarket\", \"Supermarket\", \"Express\"]\n",
+    "\n",
+    "# Hero mapping (so the blog's flagship 'Skim Milk in the Northeast' question hits a real surge SKU).\n",
+    "HERO_PRODUCT_ID, HERO_PRODUCT_NAME, HERO_CATEGORY, HERO_SUBCAT = 122, \"Skim Milk\", \"Dairy\", \"Fresh Milk\"\n",
+    "HERO_CITY_ID, HERO_CITY_NAME, HERO_REGION, HERO_STATE = 0, \"Boston\", \"Northeast\", \"MA\"\n",
+    "print(\"vocab ready\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. product_dim — deterministic synthetic names keyed to real product_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "product_ids = sorted(r.product_id for r in spark.table(SRC).select(\"product_id\").distinct().collect())\n",
+    "city_ids    = sorted(r.city_id    for r in spark.table(SRC).select(\"city_id\").distinct().collect())\n",
+    "print(f\"distinct products: {len(product_ids)} | distinct cities: {len(city_ids)}\")\n",
+    "\n",
+    "cat_list = list(CATEGORIES.items())\n",
+    "\n",
+    "def name_for_product(pid: int):\n",
+    "    \"\"\"Deterministic: pid -> (name, category, subcategory, brand, base_price).\"\"\"\n",
+    "    if pid == HERO_PRODUCT_ID:\n",
+    "        return (HERO_PRODUCT_NAME, HERO_CATEGORY, HERO_SUBCAT,\n",
+    "                BRANDS[pid % len(BRANDS)], round(1.99 + (pid % 7) * 0.50, 2))\n",
+    "    cat, subs = cat_list[pid % len(cat_list)]\n",
+    "    sub = subs[(pid // len(cat_list)) % len(subs)]\n",
+    "    words = PRODUCT_WORDS.get(sub, [sub])\n",
+    "    base = words[(pid // 7) % len(words)]\n",
+    "    # make names unique-ish by appending a pack/size variant deterministically\n",
+    "    variant = [\"\", \" (Family Pack)\", \" (Single)\", \" 1L\", \" 2L\", \" 500g\", \" 12-pack\"][pid % 7]\n",
+    "    return (f\"{base}{variant}\", cat, sub, BRANDS[pid % len(BRANDS)],\n",
+    "            round(1.49 + (pid % 20) * 0.40, 2))\n",
+    "\n",
+    "prod_rows = []\n",
+    "for pid in product_ids:\n",
+    "    nm, cat, sub, brand, price = name_for_product(int(pid))\n",
+    "    prod_rows.append((int(pid), nm, cat, sub, brand, float(price)))\n",
+    "\n",
+    "product_dim = spark.createDataFrame(\n",
+    "    prod_rows, [\"product_id\", \"product_name\", \"category\", \"subcategory\", \"brand\", \"base_price\"])\n",
+    "(product_dim.write.mode(\"overwrite\").option(\"overwriteSchema\", \"true\")\n",
+    "  .saveAsTable(f\"{CATALOG}.{SCHEMA}.product_dim\"))\n",
+    "print(f\"wrote product_dim: {product_dim.count()} rows\")\n",
+    "display(product_dim.orderBy(\"product_id\").limit(8))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. location_dim — deterministic synthetic city/region keyed to real city_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loc_rows = []\n",
+    "for idx, cid in enumerate(city_ids):\n",
+    "    cid = int(cid)\n",
+    "    if cid == HERO_CITY_ID:\n",
+    "        city, region, state = HERO_CITY_NAME, HERO_REGION, HERO_STATE\n",
+    "    else:\n",
+    "        city = CITY_NAMES[idx % len(CITY_NAMES)]\n",
+    "        region = REGION_OF_CITY.get(city, REGIONS[idx % len(REGIONS)])\n",
+    "        state = STATE_OF_CITY.get(city, \"NA\")\n",
+    "    store_type = STORE_TYPES[cid % len(STORE_TYPES)]\n",
+    "    loc_rows.append((cid, city, region, state, store_type))\n",
+    "\n",
+    "location_dim = spark.createDataFrame(\n",
+    "    loc_rows, [\"city_id\", \"city_name\", \"region\", \"state\", \"store_type\"])\n",
+    "(location_dim.write.mode(\"overwrite\").option(\"overwriteSchema\", \"true\")\n",
+    "  .saveAsTable(f\"{CATALOG}.{SCHEMA}.location_dim\"))\n",
+    "print(f\"wrote location_dim: {location_dim.count()} rows\")\n",
+    "display(location_dim.orderBy(\"city_id\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Verify the hero SKU and that dims join to the forecast\n",
+    "\n",
+    "Surge SKU `18_122` should resolve to **Skim Milk** in the **Northeast** (Boston)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%sql\n",
+    "SELECT s.unique_id, p.product_name, p.category, l.city_name, l.region,\n",
+    "       ROUND(SUM(f.forecast_value), 1) AS forecast_7d\n",
+    "FROM mmf.fresh_retail_net.demand_train s\n",
+    "JOIN mmf.fresh_retail_net.product_dim  p ON s.product_id = p.product_id\n",
+    "JOIN mmf.fresh_retail_net.location_dim l ON s.city_id    = l.city_id\n",
+    "JOIN mmf.fresh_retail_net.scoring_output_mv f ON s.unique_id = f.unique_id\n",
+    "WHERE s.unique_id IN ('18_122','299_300','3_191','561_261','450_300','375_4')\n",
+    "GROUP BY s.unique_id, p.product_name, p.category, l.city_name, l.region\n",
+    "ORDER BY forecast_7d DESC;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Next steps\n",
+    "\n",
+    "Add `product_dim` and `location_dim` to the **Fresh Retail Sales Forecasting** Genie space, and extend the\n",
+    "Genie instructions so it maps names → ids:\n",
+    "\n",
+    "> A SKU's product name comes from `product_dim` (join on product_id); its region/city from `location_dim`\n",
+    "> (join on city_id). When a user names a product (e.g. \"Skim Milk\") or region (e.g. \"Northeast\"), resolve\n",
+    "> it via these tables to the relevant unique_id(s) before querying demand or forecasts.\n",
+    "\n",
+    "The supplier feed (`supply_chain.supplier_availability` in S3 Tables) joins on `product_id` + `city_id`, so\n",
+    "orders can display the product name and region while matching on the real ids."
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "2"
+   },
+   "language": "python",
+   "notebookName": "build_product_location_dims",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/fresh_retail_net/04_genie_views_setup.ipynb
+++ b/examples/fresh_retail_net/04_genie_views_setup.ipynb
@@ -3,7 +3,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Genie Views Setup — Explode MMF Array Outputs for Genie / Amazon Quick\n\n`mmf.fresh_retail_net.scoring_output` and `evaluation_output` store forecasts as **ARRAY columns**\n(7-element, one per horizon day) plus a **binary `model_pickle`**. Databricks Genie's NL→SQL works on\nflat scalar columns; it cannot reason over array/binary columns. This notebook creates **exploded views**\nso Genie (and therefore Amazon Quick via MCP) can query the forecasts and backtest metrics cleanly.\n\n**Single-model scope:** the views are filtered to `MODEL_FILTER` (default `Chronos2`), so the Genie space\nexposes **only Chronos-2 data** — keeping the demo consistent with the blog (Chronos-2 is the only named\nmodel) and removing any model-comparison surface.\n\n### What it creates (in `mmf.fresh_retail_net`, additive — source tables are NOT modified)\n| View | Source | Purpose |\n|---|---|---|\n| `scoring_output_mv` | `scoring_output` | one row per (unique_id, forecast_date) — Chronos-2 forecasts |\n| `evaluation_metrics_mv` | `evaluation_output` | scalar per-series backtest metrics (SMAPE), arrays/pickle dropped |\n| `evaluation_backtest_mv` | `evaluation_output` | exploded forecast-vs-actual pairs per backtest step |\n\n### Materialized view vs. view\nMaterialized views pre-compute the explode → fast Genie/Quick queries (no 60s-timeout risk). They require\na **Serverless SQL Warehouse**. If MV creation fails on this compute, the notebook **automatically falls\nback to plain VIEWs** (which work anywhere but re-run the explode per query). Set `USE_MATERIALIZED` below.\n\n### Prerequisites\n- Attach to **Serverless** compute (SQL warehouse or serverless notebook).\n- The source tables already exist from the original MMF run."
+   "source": [
+    "# Genie Views Setup \u2014 Flatten MMF Array Outputs for Natural-Language Access\n",
+    "\n",
+    "`mmf.fresh_retail_net.scoring_output` and `evaluation_output` store forecasts as **ARRAY columns** ",
+    "(7-element, one per horizon day) plus a **binary `model_pickle`**. Databricks Genie's NL\u2192SQL works on ",
+    "flat scalar columns; it cannot reason over array/binary columns. This notebook creates **exploded views** ",
+    "so any Databricks-on-AWS user can put a Genie Space (or any BI/agent consumer, e.g. Amazon Quick) over MMF output.\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -17,7 +24,23 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "CATALOG = \"mmf\"\nSCHEMA  = \"fresh_retail_net\"\nUSE_MATERIALIZED = True   # True -> MATERIALIZED VIEW (needs serverless); False -> plain VIEW\n\n# Restrict the Genie-facing views to a single model so the space exposes ONLY Chronos-2 data.\n# This keeps the demo consistent with the blog (Chronos-2 is the only named model) and removes any\n# model-comparison surface (no \"which model is best\" answer). Set to None to include all models.\nMODEL_FILTER = \"Chronos2\"   # exact value in scoring_output.model / evaluation_output.model\n\nsrc = lambda t: f\"{CATALOG}.{SCHEMA}.{t}\"\n# WHERE fragment applied inside each view (aliasing-aware variants built per cell).\nprint(\"MODEL_FILTER:\", MODEL_FILTER)\nprint(\"Source tables:\")\nfor t in [\"scoring_output\", \"evaluation_output\"]:\n    print(f\"  {src(t)}: {spark.table(src(t)).count():,} rows\")"
+   "source": [
+    "CATALOG = \"mmf\"\n",
+    "SCHEMA  = \"fresh_retail_net\"\n",
+    "USE_MATERIALIZED = True   # True -> MATERIALIZED VIEW (needs serverless); False -> plain VIEW\n",
+    "\n",
+    "# MMF selects the best model per series across many models \u2014 the default here exposes ALL models\n",
+    "# so Genie can answer model-comparison questions (\"which model is most accurate?\"), which is core to MMF.\n",
+    "# Optionally set to a single model name (e.g. \"Chronos2\") to scope a focused single-model demo.\n",
+    "MODEL_FILTER = None   # None = all models (recommended); or a model name (e.g. \"Chronos2\") for a focused demo\n",
+    "\n",
+    "src = lambda t: f\"{CATALOG}.{SCHEMA}.{t}\"\n",
+    "# WHERE fragment applied inside each view (aliasing-aware variants built per cell).\n",
+    "print(\"MODEL_FILTER:\", MODEL_FILTER)\n",
+    "print(\"Source tables:\")\n",
+    "for t in [\"scoring_output\", \"evaluation_output\"]:\n",
+    "    print(f\"  {src(t)}: {spark.table(src(t)).count():,} rows\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -53,7 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. `scoring_output_mv` — exploded forecasts\n",
+    "## 3. `scoring_output_mv` \u2014 exploded forecasts\n",
     "\n",
     "`ds` and `y` are aligned 7-element arrays. `arrays_zip` + `explode` gives one row per forecast day.\n",
     "The binary `model_pickle` and `model_uri` are dropped."
@@ -70,10 +93,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. `evaluation_metrics_mv` — scalar backtest metrics\n",
+    "## 4. `evaluation_metrics_mv` \u2014 scalar backtest metrics\n",
     "\n",
     "Keeps only scalar columns (per-series SMAPE etc.); drops the forecast/actual arrays and binary pickle.\n",
-    "This is what answers “which model is most accurate?” in Genie."
+    "This is what answers \u201cwhich model is most accurate?\u201d in Genie."
    ]
   },
   {
@@ -87,7 +110,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. `evaluation_backtest_mv` — exploded forecast-vs-actual (optional detail)\n",
+    "## 5. `evaluation_backtest_mv` \u2014 exploded forecast-vs-actual (optional detail)\n",
     "\n",
     "Pairs predicted vs actual per backtest horizon step. Note: `evaluation_output` stores only the window\n",
     "*start* date plus arrays (no per-step dates), so this is by horizon position, not calendar date."
@@ -104,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 6. Validate — row counts, schema, and a sample of each view"
+    "## 6. Validate \u2014 row counts, schema, and a sample of each view"
    ]
   },
   {
@@ -151,8 +174,8 @@
     "Add these views to the **Fresh Retail Sales Forecasting** Genie space instead of the raw array tables:\n",
     "- `mmf.fresh_retail_net.daily_sales_raw` (history + covariates)\n",
     "- `mmf.fresh_retail_net.demand_train` (clean per-SKU history)\n",
-    "- `mmf.fresh_retail_net.scoring_output_mv` (forecasts) ← instead of `scoring_output`\n",
-    "- `mmf.fresh_retail_net.evaluation_metrics_mv` (model accuracy) ← instead of `evaluation_output`\n",
+    "- `mmf.fresh_retail_net.scoring_output_mv` (forecasts) \u2190 instead of `scoring_output`\n",
+    "- `mmf.fresh_retail_net.evaluation_metrics_mv` (model accuracy) \u2190 instead of `evaluation_output`\n",
     "\n",
     "Skip `demand_score` (MMF scaffolding). All views are built only from the original MMF run output."
    ]

--- a/examples/fresh_retail_net/04_genie_views_setup.ipynb
+++ b/examples/fresh_retail_net/04_genie_views_setup.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Genie Views Setup — Explode MMF Array Outputs for Genie / Amazon Quick\n\n`mmf.fresh_retail_net.scoring_output` and `evaluation_output` store forecasts as **ARRAY columns**\n(7-element, one per horizon day) plus a **binary `model_pickle`**. Databricks Genie's NL→SQL works on\nflat scalar columns; it cannot reason over array/binary columns. This notebook creates **exploded views**\nso Genie (and therefore Amazon Quick via MCP) can query the forecasts and backtest metrics cleanly.\n\n**Single-model scope:** the views are filtered to `MODEL_FILTER` (default `Chronos2`), so the Genie space\nexposes **only Chronos-2 data** — keeping the demo consistent with the blog (Chronos-2 is the only named\nmodel) and removing any model-comparison surface.\n\n### What it creates (in `mmf.fresh_retail_net`, additive — source tables are NOT modified)\n| View | Source | Purpose |\n|---|---|---|\n| `scoring_output_mv` | `scoring_output` | one row per (unique_id, forecast_date) — Chronos-2 forecasts |\n| `evaluation_metrics_mv` | `evaluation_output` | scalar per-series backtest metrics (SMAPE), arrays/pickle dropped |\n| `evaluation_backtest_mv` | `evaluation_output` | exploded forecast-vs-actual pairs per backtest step |\n\n### Materialized view vs. view\nMaterialized views pre-compute the explode → fast Genie/Quick queries (no 60s-timeout risk). They require\na **Serverless SQL Warehouse**. If MV creation fails on this compute, the notebook **automatically falls\nback to plain VIEWs** (which work anywhere but re-run the explode per query). Set `USE_MATERIALIZED` below.\n\n### Prerequisites\n- Attach to **Serverless** compute (SQL warehouse or serverless notebook).\n- The source tables already exist from the original MMF run."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "CATALOG = \"mmf\"\nSCHEMA  = \"fresh_retail_net\"\nUSE_MATERIALIZED = True   # True -> MATERIALIZED VIEW (needs serverless); False -> plain VIEW\n\n# Restrict the Genie-facing views to a single model so the space exposes ONLY Chronos-2 data.\n# This keeps the demo consistent with the blog (Chronos-2 is the only named model) and removes any\n# model-comparison surface (no \"which model is best\" answer). Set to None to include all models.\nMODEL_FILTER = \"Chronos2\"   # exact value in scoring_output.model / evaluation_output.model\n\nsrc = lambda t: f\"{CATALOG}.{SCHEMA}.{t}\"\n# WHERE fragment applied inside each view (aliasing-aware variants built per cell).\nprint(\"MODEL_FILTER:\", MODEL_FILTER)\nprint(\"Source tables:\")\nfor t in [\"scoring_output\", \"evaluation_output\"]:\n    print(f\"  {src(t)}: {spark.table(src(t)).count():,} rows\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Helper: create as MV, fall back to VIEW on failure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_view(name, select_sql):\n",
+    "    \"\"\"Create name as a MATERIALIZED VIEW if USE_MATERIALIZED, else a VIEW.\n",
+    "    Falls back to plain VIEW if MV creation is unsupported on this compute.\"\"\"\n",
+    "    fq = f\"{CATALOG}.{SCHEMA}.{name}\"\n",
+    "    if USE_MATERIALIZED:\n",
+    "        try:\n",
+    "            spark.sql(f\"DROP MATERIALIZED VIEW IF EXISTS {fq}\")\n",
+    "            spark.sql(f\"CREATE MATERIALIZED VIEW {fq} AS\\n{select_sql}\")\n",
+    "            print(f\"  created MATERIALIZED VIEW {fq}\")\n",
+    "            return\n",
+    "        except Exception as e:\n",
+    "            print(f\"  MV failed for {fq} ({type(e).__name__}); falling back to plain VIEW.\")\n",
+    "    spark.sql(f\"DROP VIEW IF EXISTS {fq}\")\n",
+    "    spark.sql(f\"CREATE VIEW {fq} AS\\n{select_sql}\")\n",
+    "    print(f\"  created VIEW {fq}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. `scoring_output_mv` — exploded forecasts\n",
+    "\n",
+    "`ds` and `y` are aligned 7-element arrays. `arrays_zip` + `explode` gives one row per forecast day.\n",
+    "The binary `model_pickle` and `model_uri` are dropped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "_where_s = f\"WHERE s.model = '{MODEL_FILTER}'\" if MODEL_FILTER else \"\"\ncreate_view(\"scoring_output_mv\", f\"\"\"\nSELECT\n  s.unique_id,\n  z.ds AS forecast_date,\n  z.y  AS forecast_value,\n  s.model,\n  s.run_id,\n  s.run_date,\n  s.use_case\nFROM {src('scoring_output')} s\nLATERAL VIEW explode(arrays_zip(s.ds, s.y)) t AS z\n{_where_s}\n\"\"\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. `evaluation_metrics_mv` — scalar backtest metrics\n",
+    "\n",
+    "Keeps only scalar columns (per-series SMAPE etc.); drops the forecast/actual arrays and binary pickle.\n",
+    "This is what answers “which model is most accurate?” in Genie."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "_where_m = f\"WHERE model = '{MODEL_FILTER}'\" if MODEL_FILTER else \"\"\ncreate_view(\"evaluation_metrics_mv\", f\"\"\"\nSELECT\n  unique_id,\n  model,\n  metric_name,\n  metric_value,\n  backtest_window_start_date,\n  run_id,\n  run_date,\n  use_case\nFROM {src('evaluation_output')}\n{_where_m}\n\"\"\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. `evaluation_backtest_mv` — exploded forecast-vs-actual (optional detail)\n",
+    "\n",
+    "Pairs predicted vs actual per backtest horizon step. Note: `evaluation_output` stores only the window\n",
+    "*start* date plus arrays (no per-step dates), so this is by horizon position, not calendar date."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "_where_e = f\"WHERE e.model = '{MODEL_FILTER}'\" if MODEL_FILTER else \"\"\ncreate_view(\"evaluation_backtest_mv\", f\"\"\"\nSELECT\n  e.unique_id,\n  e.model,\n  e.backtest_window_start_date,\n  z.forecast AS forecast_value,\n  z.actual   AS actual_value,\n  e.run_id\nFROM {src('evaluation_output')} e\nLATERAL VIEW explode(arrays_zip(e.forecast, e.actual)) t AS z\n{_where_e}\n\"\"\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Validate — row counts, schema, and a sample of each view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for v in [\"scoring_output_mv\", \"evaluation_metrics_mv\", \"evaluation_backtest_mv\"]:\n",
+    "    fq = f\"{CATALOG}.{SCHEMA}.{v}\"\n",
+    "    df = spark.table(fq)\n",
+    "    print(f\"\\n=== {fq} : {df.count():,} rows ===\")\n",
+    "    print(\"  columns:\", [f\"{f.name}:{f.dataType.simpleString()}\" for f in df.schema.fields])\n",
+    "    display(df.limit(5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "%sql\n-- Sanity: Chronos-2 average backtest SMAPE (single model; lower = better).\nSELECT model, ROUND(AVG(metric_value), 4) AS avg_smape, COUNT(*) AS n_series\nFROM mmf.fresh_retail_net.evaluation_metrics_mv\nWHERE metric_name = 'smape'\nGROUP BY model;"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%sql\n",
+    "-- Sanity: a single SKU's 7-day forecast, now one row per day.\n",
+    "SELECT unique_id, model, forecast_date, ROUND(forecast_value, 2) AS forecast_value\n",
+    "FROM mmf.fresh_retail_net.scoring_output_mv\n",
+    "ORDER BY unique_id, model, forecast_date\n",
+    "LIMIT 14;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Next steps\n",
+    "\n",
+    "Add these views to the **Fresh Retail Sales Forecasting** Genie space instead of the raw array tables:\n",
+    "- `mmf.fresh_retail_net.daily_sales_raw` (history + covariates)\n",
+    "- `mmf.fresh_retail_net.demand_train` (clean per-SKU history)\n",
+    "- `mmf.fresh_retail_net.scoring_output_mv` (forecasts) ← instead of `scoring_output`\n",
+    "- `mmf.fresh_retail_net.evaluation_metrics_mv` (model accuracy) ← instead of `evaluation_output`\n",
+    "\n",
+    "Skip `demand_score` (MMF scaffolding). All views are built only from the original MMF run output."
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "2"
+   },
+   "language": "python",
+   "notebookName": "genie_views_setup",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/fresh_retail_net/README.md
+++ b/examples/fresh_retail_net/README.md
@@ -1,0 +1,41 @@
+# FreshRetailNet — Serverless MMF example
+
+An end-to-end example that runs Many-Model Forecasting (MMF) on the public
+**FreshRetailNet** dataset on **Databricks Serverless GPU**, then makes the
+forecast output consumable in natural language via a Databricks Genie Space.
+
+## Notebooks
+
+| Notebook | Purpose |
+|----------|---------|
+| `01_fresh_retail_net_data_prep.ipynb` | Loads the public FreshRetailNet dataset (commercial-permissive license) and prepares it for MMF. Runs on standard Serverless. |
+| `02_fresh_retail_net_mmf_forecast.ipynb` | Runs MMF foundation models on the prepared dataset. Requires **A10 Serverless GPU** compute — see the setup section at the top of the notebook. |
+| `03_build_product_location_dims.ipynb` | Builds illustrative product and location dimension tables so FreshRetailNet's anonymized integer IDs (`product_id`, `city_id`, category IDs) map to friendly labels, making the forecast queryable in natural language. |
+| `04_genie_views_setup.ipynb` | Explodes MMF's `scoring_output` / `evaluation_output` 7-element `ARRAY` columns into flat, one-row-per-day views so Databricks Genie (natural-language-to-SQL) can reason over the forecast output. |
+
+Notebooks `01` and `02` are the core MMF pipeline; `03` and `04` are
+complementary and self-contained — they build on the forecast output for a
+downstream Genie / BI demo and do not modify `01`/`02`.
+
+## Compute
+
+All notebooks are written for the **Serverless GPU (Spark Connect)** environment
+that `examples/serverless/` targets. `02` requires an A10 GPU instance
+(environment version 5); the others run on standard Serverless.
+
+## Data note
+
+FreshRetailNet anonymizes all entities to integer IDs — there are no product
+names or regions in the source data. The product and location labels created in
+`03_build_product_location_dims.ipynb` (e.g. "Skim Milk," "Northeast") are
+**illustrative only** and are not real data from any customer.
+
+## Credits
+
+- Core FreshRetailNet MMF notebooks (`01`, `02`): Ryuta Yoshimatsu (Databricks).
+- Serverless-GPU data-prep fixes in `01` (guarded catalog creation; removal of
+  `.cache()` on Spark Connect) and the complementary notebooks (`03`, `04`):
+  Venkatavaradhan Viswanathan (AWS, [@venkatavaradhanv](https://github.com/venkatavaradhanv)).
+
+This example accompanies the joint Databricks × AWS blog on multi-modal
+supply-chain forecasting with MMF, Databricks Genie, and Amazon Quick.

--- a/examples/fresh_retail_net/README.md
+++ b/examples/fresh_retail_net/README.md
@@ -11,7 +11,7 @@ forecast output consumable in natural language via a Databricks Genie Space.
 | `01_fresh_retail_net_data_prep.ipynb` | Loads the public FreshRetailNet dataset (commercial-permissive license) and prepares it for MMF. Runs on standard Serverless. |
 | `02_fresh_retail_net_mmf_forecast.ipynb` | Runs MMF foundation models on the prepared dataset. Requires **A10 Serverless GPU** compute — see the setup section at the top of the notebook. |
 | `03_build_product_location_dims.ipynb` | Builds illustrative product and location dimension tables so FreshRetailNet's anonymized integer IDs (`product_id`, `city_id`, category IDs) map to friendly labels, making the forecast queryable in natural language. |
-| `04_genie_views_setup.ipynb` | Explodes MMF's `scoring_output` / `evaluation_output` 7-element `ARRAY` columns into flat, one-row-per-day views so Databricks Genie (natural-language-to-SQL) can reason over the forecast output. |
+| `04_genie_views_setup.ipynb` | Explodes MMF's `scoring_output` / `evaluation_output` 7-element `ARRAY` columns into flat, one-row-per-day views so Databricks Genie (natural-language-to-SQL) can reason over the forecast output. Exposes **all** MMF models by default so Genie can answer model-comparison questions; optionally scope to one model for a focused demo. |
 
 Notebooks `01` and `02` are the core MMF pipeline; `03` and `04` are
 complementary and self-contained — they build on the forecast output for a


### PR DESCRIPTION
## What

Adds `examples/fresh_retail_net/` — an end-to-end example running Many-Model Forecasting on the public **FreshRetailNet** dataset on **Databricks Serverless GPU**, plus complementary notebooks that make the forecast output consumable in natural language via a Databricks Genie Space.

| Notebook | Purpose |
|----------|---------|
| `01_fresh_retail_net_data_prep` | Load + prep the public FreshRetailNet dataset. Includes two Serverless-GPU (Spark Connect) fixes: guarded catalog creation (avoids the UC `IF NOT EXISTS` storage-root validation error) and removal of `.cache()` on the sampled IDs. |
| `02_fresh_retail_net_mmf_forecast` | Run MMF foundation models (A10 Serverless GPU). |
| `03_build_product_location_dims` | Illustrative product/location dimension tables so FreshRetailNet's anonymized integer IDs map to friendly labels for NL queries. |
| `04_genie_views_setup` | Flatten MMF's `ARRAY` scoring/evaluation output into scalar views so Databricks Genie (and any BI/agent consumer) can query it. |

## Notes for reviewers

- **01/02** are the core MMF pipeline; the two data-prep fixes in `01` target the same Serverless-GPU environment as `examples/serverless/`, so they may be worth pulling upstream regardless.
- **04 defaults to all MMF models** (`MODEL_FILTER = None`) so Genie can answer model-comparison questions — MMF's per-series model-selection story stays front and center. A single-model filter is available for a focused demo.
- The product/location labels in `03` are **synthetic and illustrative only** — not real data from any customer.

## Credits

- Core FreshRetailNet notebooks (`01`, `02`): Ryuta Yoshimatsu (Databricks).
- Serverless-GPU fixes + complementary notebooks (`03`, `04`): Venkatavaradhan Viswanathan (AWS, @venkatavaradhanv).

Accompanies the joint Databricks × AWS blog on multi-modal supply-chain forecasting (MMF + Genie + Amazon Quick).