### PR TITLE
Fix Skill 5 best-model selection across multi-job run_ids

### DIFF
--- a/skills/databricks-skills/many-model-forecasting/4-execute-mmf-forecast.md
+++ b/skills/databricks-skills/many-model-forecasting/4-execute-mmf-forecast.md
@@ -371,7 +371,11 @@ Present all parameters to the user via `AskUserQuestion` for validation.
 
 **CRITICAL: Copy templates VERBATIM, only replacing `{placeholder}` tokens with actual values. Do NOT add, remove, or modify any other code. The templates are complete and production-ready.**
 
-Generate a shared `run_id` (UUID) that will be passed to all notebooks, grouping results across separate sessions.
+> ℹ️ **`run_id` is per-job, not shared.** Each model-class job calls `run_forecast`, which
+> generates its **own** `run_id` (UUID) internally. Do **not** try to force a single shared
+> `run_id` across jobs — Skill 5 handles this correctly by selecting the **latest `run_id` per
+> model** so all models compete together. (An earlier version pinned Skill 5 to a single global
+> latest run, which silently excluded every model except the last job to finish.)
 
 #### 3a: Local models notebook
 
@@ -1084,7 +1088,12 @@ Write run metadata to `{use_case}_run_metadata` table for audit and reproducibil
 CREATE OR REPLACE TABLE {catalog}.{schema}.{use_case}_run_metadata AS
 SELECT
   '{use_case}' AS use_case,
-  '{run_id}' AS run_id,
+  -- Each model-class job writes its own run_id (local/global_ml generate one internally;
+  -- each GPU orchestrator generates one and shares it across the models in that job).
+  -- Capture every run_id present in the evaluation output so lineage reflects all jobs
+  -- that contributed — Skill 5 selects the latest run_id per model across these.
+  (SELECT ARRAY_AGG(DISTINCT run_id)
+   FROM {catalog}.{schema}.{use_case}_evaluation_output) AS run_ids,
   CURRENT_TIMESTAMP() AS run_date,
   '{freq}' AS freq,
   {prediction_length} AS prediction_length,

--- a/skills/databricks-skills/many-model-forecasting/5-post-process-and-evaluate.md
+++ b/skills/databricks-skills/many-model-forecasting/5-post-process-and-evaluate.md
@@ -136,27 +136,68 @@ GROUP BY unique_id, model
 
 Select the best-performing model for each forecastable time series based on the primary metric:
 
+> ⚠️ **Why `latest_run_per_model` and not a single global latest run.** MMF launches
+> **one job per model class** (local, global_ml, global, foundation — see Skill 4 Step 5b),
+> and each job's `run_forecast` call writes its **own** `run_id`. Pinning selection to a
+> single global latest `run_id` (e.g. `ORDER BY run_date DESC LIMIT 1`) keeps only the
+> **last job to finish** and silently drops every other model from the competition — the
+> classic "foundation models won 100%" artifact. Instead, take the most recent `run_id`
+> for **each model** so all models that were run compete head-to-head. This stays coherent
+> for hierarchical reconciliation (Skill 6): a model's forecast (`scoring_output`) and its
+> backtest residuals (`evaluation_output`) share the same `run_id`, and reconciliation joins
+> residuals **per `(unique_id, model, run_id)`** — so per-model pinning is exactly the grain it needs.
+>
+> **Tie-break policy.** Selection uses `ROW_NUMBER()` (not `RANK()`) so exactly **one** model
+> wins per series — no duplicate best-model rows that would inflate win counts and break
+> reconciliation's one-forecast-per-series contract. On an exact metric tie, the **cheaper /
+> simpler compute tier wins** (local → global ML → global DL → foundation), with model name as
+> a final deterministic fallback. This avoids letting an expensive GPU model win a break-even by
+> alphabetical accident and matches the Step 8 guidance to prefer local models when accuracy is comparable.
+
 ```sql
 CREATE OR REPLACE TABLE {catalog}.{schema}.{use_case}_best_models_forecastable AS
-WITH latest_run AS (
-  -- evaluation_output and scoring_output are append-mode and may accumulate multiple
-  -- runs. Pin selection AND the attached forecasts to a single, most-recent run so the
-  -- chosen forecasts and their backtest residuals come from the same run (required by
-  -- hierarchical reconciliation, which joins residuals on run_id).
-  SELECT run_id
-  FROM {catalog}.{schema}.{use_case}_evaluation_output
-  ORDER BY run_date DESC
-  LIMIT 1
+WITH latest_run_per_model AS (
+  -- evaluation_output/scoring_output are append-mode and accumulate runs across the
+  -- separate per-model-class jobs (and any re-runs). For EACH model, pick the run_id
+  -- from its most recent run so every model competes on its latest results.
+  SELECT model, run_id
+  FROM (
+    SELECT model, run_id,
+           ROW_NUMBER() OVER (PARTITION BY model ORDER BY run_date DESC, run_id DESC) AS rn
+    FROM (
+      SELECT DISTINCT model, run_id, run_date
+      FROM {catalog}.{schema}.{use_case}_evaluation_output
+    )
+  )
+  WHERE rn = 1
 )
 SELECT eval.unique_id, eval.model, eval.avg_metric, score.ds, score.y,
        'main_pipeline' AS forecast_source, eval.run_id
 FROM (
   SELECT unique_id, model, run_id, avg_metric,
-         RANK() OVER (PARTITION BY unique_id ORDER BY avg_metric ASC) AS rank
+         ROW_NUMBER() OVER (
+           PARTITION BY unique_id
+           ORDER BY
+             avg_metric ASC,
+             -- Tie-break: prefer the cheaper/simpler model when metrics are equal, so a
+             -- break-even never gets decided by an expensive GPU model (or by alphabetical
+             -- accident). Lower rank = cheaper compute tier. ROW_NUMBER (not RANK) guarantees
+             -- exactly ONE winning row per series — no duplicate best-model rows downstream.
+             CASE
+               WHEN model LIKE 'StatsForecast%' OR model LIKE 'SKTime%' THEN 1  -- local (CPU)
+               WHEN model LIKE 'MLForecast%'                            THEN 2  -- global ML (CPU, LightGBM)
+               WHEN model LIKE 'NeuralForecast%'                        THEN 3  -- global DL (GPU)
+               WHEN model LIKE 'Chronos%' OR model LIKE 'Moirai%'
+                    OR model LIKE 'TimesFM%'                            THEN 4  -- foundation (GPU)
+               ELSE 5                                                          -- unknown/custom: least preferred on ties
+             END ASC,
+             model ASC  -- final deterministic fallback within the same cost tier
+         ) AS rank
   FROM (
     SELECT e.unique_id, e.model, e.run_id, AVG(e.metric_value) AS avg_metric
     FROM {catalog}.{schema}.{use_case}_evaluation_output AS e
-    INNER JOIN latest_run AS lr ON e.run_id = lr.run_id
+    INNER JOIN latest_run_per_model AS lr
+      ON e.model = lr.model AND e.run_id = lr.run_id
     GROUP BY e.unique_id, e.model, e.run_id
     HAVING AVG(e.metric_value) IS NOT NULL
   )
@@ -208,21 +249,47 @@ FROM {catalog}.{schema}.{use_case}_best_models_forecastable
 
 UNION ALL
 
--- Non-forecastable best models (from separate pipeline)
+-- Non-forecastable best models (from separate pipeline). Same per-model run_id logic as
+-- Step 3: the non-forecastable models are also launched as separate per-class jobs, so pick
+-- each model's latest run_id rather than a single global latest run.
 SELECT nf_eval.unique_id, nf_eval.model, nf_eval.avg_metric, nf_score.ds, nf_score.y,
        'non_forecastable_pipeline' AS forecast_source, nf_eval.run_id
 FROM (
   SELECT unique_id, model, run_id, avg_metric,
-         RANK() OVER (PARTITION BY unique_id ORDER BY avg_metric ASC) AS rank
+         ROW_NUMBER() OVER (
+           PARTITION BY unique_id
+           ORDER BY
+             avg_metric ASC,
+             -- Tie-break: prefer the cheaper/simpler model when metrics are equal, so a
+             -- break-even never gets decided by an expensive GPU model (or by alphabetical
+             -- accident). Lower rank = cheaper compute tier. ROW_NUMBER (not RANK) guarantees
+             -- exactly ONE winning row per series — no duplicate best-model rows downstream.
+             CASE
+               WHEN model LIKE 'StatsForecast%' OR model LIKE 'SKTime%' THEN 1  -- local (CPU)
+               WHEN model LIKE 'MLForecast%'                            THEN 2  -- global ML (CPU, LightGBM)
+               WHEN model LIKE 'NeuralForecast%'                        THEN 3  -- global DL (GPU)
+               WHEN model LIKE 'Chronos%' OR model LIKE 'Moirai%'
+                    OR model LIKE 'TimesFM%'                            THEN 4  -- foundation (GPU)
+               ELSE 5                                                          -- unknown/custom: least preferred on ties
+             END ASC,
+             model ASC  -- final deterministic fallback within the same cost tier
+         ) AS rank
   FROM (
     SELECT e.unique_id, e.model, e.run_id, AVG(e.metric_value) AS avg_metric
     FROM {catalog}.{schema}.{use_case}_nf_evaluation_output AS e
     INNER JOIN (
-      SELECT run_id
-      FROM {catalog}.{schema}.{use_case}_nf_evaluation_output
-      ORDER BY run_date DESC
-      LIMIT 1
-    ) AS nf_latest_run ON e.run_id = nf_latest_run.run_id
+      SELECT model, run_id
+      FROM (
+        SELECT model, run_id,
+               ROW_NUMBER() OVER (PARTITION BY model ORDER BY run_date DESC, run_id DESC) AS rn
+        FROM (
+          SELECT DISTINCT model, run_id, run_date
+          FROM {catalog}.{schema}.{use_case}_nf_evaluation_output
+        )
+      )
+      WHERE rn = 1
+    ) AS nf_latest_run_per_model
+      ON e.model = nf_latest_run_per_model.model AND e.run_id = nf_latest_run_per_model.run_id
     GROUP BY e.unique_id, e.model, e.run_id
     HAVING AVG(e.metric_value) IS NOT NULL
   )

--- a/skills/databricks-skills/many-model-forecasting/mmf_post_process_notebook_template.ipynb
+++ b/skills/databricks-skills/many-model-forecasting/mmf_post_process_notebook_template.ipynb
@@ -13,19 +13,21 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "catalog = \"{catalog}\"\n",
         "schema = \"{schema}\"\n",
         "use_case = \"{use_case}\"\n",
         "metric = \"{metric}\""
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "eval_table = f\"{catalog}.{schema}.{use_case}_evaluation_output\"\n",
         "score_table = f\"{catalog}.{schema}.{use_case}_scoring_output\"\n",
@@ -36,13 +38,13 @@
         "print(f\"Scoring output:    {score_count:,} rows in {score_table}\")\n",
         "assert eval_count > 0, f\"Evaluation table {eval_table} is empty\"\n",
         "assert score_count > 0, f\"Scoring table {score_table} is empty\""
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "eval_table = f\"{catalog}.{schema}.{use_case}_evaluation_output\"\n",
         "score_table = f\"{catalog}.{schema}.{use_case}_scoring_output\"\n",
@@ -51,21 +53,47 @@
         "\n",
         "spark.sql(f\"\"\"\n",
         "CREATE OR REPLACE TABLE {best_forecastable_table} AS\n",
-        "WITH latest_run AS (\n",
-        "  SELECT run_id\n",
-        "  FROM {eval_table}\n",
-        "  ORDER BY run_date DESC\n",
-        "  LIMIT 1\n",
+        "WITH latest_run_per_model AS (\n",
+        "  -- MMF runs one job per model class, each writing its own run_id. Pick each model's\n",
+        "  -- most recent run_id (not a single global latest run) so all models compete head-to-head.\n",
+        "  -- A model's forecast and residuals share the same run_id, so this stays coherent for\n",
+        "  -- hierarchical reconciliation (which joins residuals per unique_id/model/run_id).\n",
+        "  SELECT model, run_id\n",
+        "  FROM (\n",
+        "    SELECT model, run_id,\n",
+        "           ROW_NUMBER() OVER (PARTITION BY model ORDER BY run_date DESC, run_id DESC) AS rn\n",
+        "    FROM (\n",
+        "      SELECT DISTINCT model, run_id, run_date\n",
+        "      FROM {eval_table}\n",
+        "    )\n",
+        "  )\n",
+        "  WHERE rn = 1\n",
         ")\n",
         "SELECT eval.unique_id, eval.model, eval.avg_metric, score.ds, score.y,\n",
         "       'main_pipeline' AS forecast_source, eval.run_id\n",
         "FROM (\n",
         "  SELECT unique_id, model, run_id, avg_metric,\n",
-        "         RANK() OVER (PARTITION BY unique_id ORDER BY avg_metric ASC) AS rank\n",
+        "         ROW_NUMBER() OVER (\n",
+        "           PARTITION BY unique_id\n",
+        "           ORDER BY\n",
+        "             avg_metric ASC,\n",
+        "             -- Tie-break: prefer the cheaper/simpler model on equal metrics (lower cost tier\n",
+        "             -- wins). ROW_NUMBER guarantees exactly one winning row per series.\n",
+        "             CASE\n",
+        "               WHEN model LIKE 'StatsForecast%' OR model LIKE 'SKTime%' THEN 1\n",
+        "               WHEN model LIKE 'MLForecast%'                            THEN 2\n",
+        "               WHEN model LIKE 'NeuralForecast%'                        THEN 3\n",
+        "               WHEN model LIKE 'Chronos%' OR model LIKE 'Moirai%'\n",
+        "                    OR model LIKE 'TimesFM%'                            THEN 4\n",
+        "               ELSE 5\n",
+        "             END ASC,\n",
+        "             model ASC\n",
+        "         ) AS rank\n",
         "  FROM (\n",
         "    SELECT e.unique_id, e.model, e.run_id, AVG(e.metric_value) AS avg_metric\n",
         "    FROM {eval_table} AS e\n",
-        "    INNER JOIN latest_run AS lr ON e.run_id = lr.run_id\n",
+        "    INNER JOIN latest_run_per_model AS lr\n",
+        "      ON e.model = lr.model AND e.run_id = lr.run_id\n",
         "    GROUP BY e.unique_id, e.model, e.run_id\n",
         "    HAVING AVG(e.metric_value) IS NOT NULL\n",
         "  )\n",
@@ -83,13 +111,13 @@
         "\n",
         "best_count = spark.sql(f\"SELECT COUNT(*) AS cnt FROM {best_table}\").collect()[0][\"cnt\"]\n",
         "print(f\"Best model selection: {best_count:,} rows in {best_table}\")"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "best_table = f\"{catalog}.{schema}.{use_case}_best_models\"\n",
         "summary_table = f\"{catalog}.{schema}.{use_case}_evaluation_summary\"\n",
@@ -109,13 +137,13 @@
         "\n",
         "print(\"Model ranking:\")\n",
         "spark.sql(f\"SELECT model, wins_count, wins_pct, avg_smape FROM {summary_table}\").show(truncate=False)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "best_table = f\"{catalog}.{schema}.{use_case}_best_models\"\n",
         "\n",
@@ -139,13 +167,13 @@
         "ORDER BY avg_metric DESC\n",
         "LIMIT 10\n",
         "\"\"\").show(truncate=False)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
+      "outputs": [],
       "source": [
         "best_table = f\"{catalog}.{schema}.{use_case}_best_models\"\n",
         "profile_table = f\"{catalog}.{schema}.{use_case}_series_profile\"\n",
@@ -166,9 +194,7 @@
         "    \"\"\").show(truncate=False)\n",
         "except Exception:\n",
         "    print(\"Series profile table not found — skipping cross-reference.\")"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary

Skill 5 (`/post-process-and-evaluate`) selected the best model per series by pinning to a **single global latest `run_id`**. But MMF launches **one job per model class** (local, global_ml, global_dl, foundation — Skill 4 Step 5b), and each `run_forecast` call generates its **own** `run_id` (a fresh `uuid` in `mmf_sa/Forecaster.py`). The foundation job finishes last, so the "latest `run_id`" contained only foundation models — every local, ML, and neural model was silently excluded from the competition.

This produced the **"foundation models won 100% of series"** artifact: the 34 local/ML/neural models were never actually in the same competition as the 8 foundation models.

## Root cause

- Each model-class job writes a distinct `run_id`; there is no shared `run_id` across jobs. (Skill 4 Step 3 previously *claimed* to generate a shared `run_id`, but the notebook templates never pass one — so the claim was false.)
- Skill 5's `ORDER BY run_date DESC LIMIT 1` therefore selected only the last job to finish.

## Fix

**1. Select the latest `run_id` per model** (not a single global latest run), so all models that were run compete head-to-head:

```sql
WITH latest_run_per_model AS (
  SELECT model, run_id
  FROM (
    SELECT model, run_id,
           ROW_NUMBER() OVER (PARTITION BY model ORDER BY run_date DESC, run_id DESC) AS rn
    FROM (SELECT DISTINCT model, run_id, run_date FROM {use_case}_evaluation_output)
  )
  WHERE rn = 1
)
```

This is safe for **hierarchical reconciliation (Skill 6)**: reconciliation joins residuals per `(unique_id, model, run_id)` (`mmf_sa/reconciliation.py`, `build_residual_Y_df_from_evaluation`), not on a single global run. A model's forecast (`scoring_output`) and its backtest residuals (`evaluation_output`) always share the same `run_id`, so per-model pinning keeps each selected forecast coherent with its residuals.

**2. `RANK()` → `ROW_NUMBER()` with a cost-tiered tie-break.** `RANK()` kept *all* tied models, producing duplicate rows per series (inflated win counts, skewed averages, and violation of reconciliation's one-forecast-per-series contract). `ROW_NUMBER()` guarantees exactly one winner. On an exact metric tie, the **cheaper compute tier wins** (local → global ML → global DL → foundation), with model name as a deterministic fallback:

```sql
ORDER BY avg_metric ASC,
  CASE
    WHEN model LIKE 'StatsForecast%' OR model LIKE 'SKTime%' THEN 1  -- local (CPU)
    WHEN model LIKE 'MLForecast%'                            THEN 2  -- global ML (CPU)
    WHEN model LIKE 'NeuralForecast%'                        THEN 3  -- global DL (GPU)
    WHEN model LIKE 'Chronos%' OR model LIKE 'Moirai%'
         OR model LIKE 'TimesFM%'                            THEN 4  -- foundation (GPU)
    ELSE 5
  END ASC,
  model ASC
```

(Tier is derived from the model-name prefix because `evaluation_output` stores only the `model` name; prefixes fully partition the catalog in `models_conf.yaml`.)

## Changes

- `5-post-process-and-evaluate.md` — Step 3 (forecastable) and Step 3a (`separate_job` non-forecastable) rewritten with the two fixes above + rationale callout.
- `mmf_post_process_notebook_template.ipynb` — Cell 3 updated to match (regenerated reproducibility notebook stays in sync).
- `4-execute-mmf-forecast.md` — replaced the false "shared `run_id`" instruction with an accurate note; fixed the now-dangling `{run_id}` placeholder in the `run_metadata` table (records all contributing `run_id`s via `ARRAY_AGG(DISTINCT run_id)`).

## Validation

Ran old vs new logic against `mmf.retail.retail_evaluation_output` (4 run_ids, one per family, 1000 series):

| | local | global ML | global DL | foundation |
|---|---|---|---|---|
| **Old (buggy)** | 0% | 0% | 0% | **100%** |
| **New (fixed)** | **42.1%** | **39.2%** | **7.3%** | **11.4%** |

- New logic: all 36 models compete; 18 distinct models win at least one series.
- Wins sum to exactly **1000** (one winner per series — no duplicate rows).
- Tie check: `series_with_ties = 0`, `max_models_tied = 1` (metrics are continuous averages; the cost tie-break is a correctness safety net).

## Test plan

- [x] Reproduced the bug on `mmf.retail.retail_evaluation_output` (100% foundation under old logic)
- [x] Verified new logic distributes wins across all four families
- [x] Verified exactly one winning row per series (no duplicates)
- [x] Confirmed reconciliation compatibility (per `(unique_id, model, run_id)` residual join)
- [x] Validated notebook template JSON is well-formed
- [ ] Optional: end-to-end rerun of Skill 5 + Skill 6 on a hierarchical use case